### PR TITLE
Fix bug when pkg-config can't find sqlite3.pc

### DIFF
--- a/wscript
+++ b/wscript
@@ -15,13 +15,11 @@ def configure(conf):
   conf.check_tool("compiler_cxx")
   conf.check_tool("node_addon")
   try:
-    conf.find_program('pkg-config', mandatory=True)
+    conf.check_cfg(package="sqlite3", args='--libs --cflags',
+                   uselib_store="SQLITE3", mandatory=True)
   except ConfigurationError:
     conf.check(lib="sqlite3", libpath=['/usr/local/lib', '/opt/local/lib'],
                uselib_store="SQLITE3", mandatory=True)
-  else:
-    conf.check_cfg(package="sqlite3", args='--libs --cflags',
-                   uselib_store="SQLITE3", mandatory=True)
 
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")


### PR DESCRIPTION
This fixes the bug which occurs in case one has pkg-config installed, but no sqlite3.pc anywhere in the system (e.g. sqlite3 was installed manually instead of using system's package manager).

Now wscript tries pkg-config method, and if it fails, falls back to lookup for local install.
