### PR TITLE
Support SmartOS builds

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,15 +1,36 @@
 {
-  'targets': [
-    {
-      'target_name': 'node_sqlite3',
-      'sources': [
-        'src/database.cc',
-        'src/node_sqlite3.cc',
-        'src/statement.cc'
-      ],
-      'dependencies': [
-        'deps/sqlite3/binding.gyp:sqlite3'
-      ]
-    }
+  'conditions': [
+    ['OS=="solaris"',
+     {
+       'targets': [
+         {
+           'target_name': 'node_sqlite3',
+           'sources': [
+             'src/database.cc',
+             'src/node_sqlite3.cc',
+             'src/statement.cc'
+           ],
+           'libraries': [
+             '-lsqlite3'
+           ]
+         }
+       ]
+     },
+     {
+       'targets': [
+         {
+           'target_name': 'node_sqlite3',
+           'sources': [
+             'src/database.cc',
+             'src/node_sqlite3.cc',
+             'src/statement.cc'
+           ],
+           'dependencies': [
+             'deps/sqlite3/binding.gyp:sqlite3'
+           ]
+         }
+       ]
+     }
+    ]
   ]
 }


### PR DESCRIPTION
Hello,

I tried to use your module, but it does not compile on SmartOS as your sqlite3 dependency results in an empty archive.  However, on SmartOS it makes more sense to just pick up sqlite from pkgsrc anyway, as that's going to be a known good build.

This change is simply to make binding.gyp look for sqlite to already be on the system, and link against that.

Sadly, I am unable to run `make test` as expresso relies on jscoverage, which also doesn't compile on SmartOS.  

FWW, I've had better luck with [cover](https://github.com/itay/node-cover) anyway, as it's (1) pure JS, and (2) only does coverage; I tend to use either node-tap or nodeunit as they are less magical than expresso/mocha.  That said, the library seems to work.

m
