### PR TITLE
Avoid writing to freed memory

### DIFF
--- a/src/async.h
+++ b/src/async.h
@@ -50,7 +50,6 @@ public:
         assert(handle->data != NULL);
         Async* async = static_cast<Async*>(handle->data);
         delete async;
-        handle->data = NULL;
     }
 
     void finish() {

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -647,7 +647,6 @@ void Statement::CloseCallback(uv_handle_t* handle) {
     assert(handle->data != NULL);
     Async* async = static_cast<Async*>(handle->data);
     delete async;
-    handle->data = NULL;
 }
 
 void Statement::AsyncEach(uv_async_t* handle, int status) {


### PR DESCRIPTION
Both of the `Async` implementations have a problem where the close routine tries to write to memory that was freed - in both cases this was causing glibc to detect heap corruption while running the tests on my system.

Basically the `handle` here is actually the `uv_async_t` object named `watcher` that is part of the `Async` object so we shouldn't try and write to it after the `Async` object has been freed.
