### PR TITLE
Move some protected methods to public

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -195,11 +195,6 @@ public:
         if (!finalized) Finalize();
     }
 
-protected:
-    static void Work_BeginPrepare(Database::Baton* baton);
-    static void Work_Prepare(uv_work_t* req);
-    static void Work_AfterPrepare(uv_work_t* req);
-
     WORK_DEFINITION(Bind);
     WORK_DEFINITION(Get);
     WORK_DEFINITION(Run);
@@ -207,10 +202,16 @@ protected:
     WORK_DEFINITION(Each);
     WORK_DEFINITION(Reset);
 
+    static Handle<Value> Finalize(const Arguments& args);
+
+protected:
+    static void Work_BeginPrepare(Database::Baton* baton);
+    static void Work_Prepare(uv_work_t* req);
+    static void Work_AfterPrepare(uv_work_t* req);
+
     static void AsyncEach(uv_async_t* handle, int status);
     static void CloseCallback(uv_handle_t* handle);
 
-    static Handle<Value> Finalize(const Arguments& args);
     static void Finalize(Baton* baton);
     void Finalize();
 


### PR DESCRIPTION
Starting with version 4.8 gcc complains about attempts to pass these protected methods to `NODE_SET_PROTOTYPE_METHOD` as the callback. An example of the errors reported is:

```
  CXX(target) Release/obj.target/node_sqlite3/src/statement.o
../src/statement.cc: In static member function ‘static void node_sqlite3::Statement::Init(v8::Handle<v8::Object>)’:
../src/statement.cc:22:65: error: no matching function for call to ‘SetPrototypeMethod(v8::Persistent<v8::FunctionTemplate>&, const char [5], <unresolved overloaded function type>)’
     NODE_SET_PROTOTYPE_METHOD(constructor_template, "bind", Bind);
                                                                 ^
../src/statement.cc:22:65: note: candidate is:
In file included from ../src/statement.cc:2:0:
/usr/include/node/node.h:119:6: note: template<class target_t> void node::SetPrototypeMethod(target_t, const char*, v8::InvocationCallback)
 void SetPrototypeMethod(target_t target,
      ^
/usr/include/node/node.h:119:6: note:   template argument deduction/substitution failed:
In file included from ../src/statement.cc:5:0:
../src/statement.cc: In substitution of ‘template<class target_t> void node::SetPrototypeMethod(target_t, const char*, v8::InvocationCallback) [with target_t = v8::Persistent<v8::FunctionTemplate>]’:
../src/statement.cc:22:65:   required from here
../src/statement.h:203:21: error: ‘static v8::Handle<v8::Value> node_sqlite3::Statement::Bind(const v8::Arguments&)’ is protected
     WORK_DEFINITION(Bind);
                     ^
../src/macros.h:125:26: note: in definition of macro ‘WORK_DEFINITION’
     static Handle<Value> name(const Arguments& args);                          \
                          ^
../src/statement.cc:22:65: error: within this context
     NODE_SET_PROTOTYPE_METHOD(constructor_template, "bind", Bind);
                                                                 ^
```

It seems that what it doesn't like is the fact that the callback method being passed is protected, and changing those methods to public allows it to compile again.

I don't know if gcc is actually right of course...

One complication is that the `WORK_DEFINITION` macro actually declares a number of functions, so this patch makes them all public - it may be better to break that up so that only the actual callback needs to be made public.
