### PR TITLE
Updated for libuv changes in node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "expresso": "*"
     },
     "engines": {
-        "node": ">= 0.6.13 && < 0.9.0"
+        "node": ">= 0.6.13 && < 0.11.0"
     },
     "scripts": {
         "test": "make test"

--- a/src/database.cc
+++ b/src/database.cc
@@ -138,7 +138,7 @@ Handle<Value> Database::New(const Arguments& args) {
 
 void Database::Work_BeginOpen(Baton* baton) {
     int status = uv_queue_work(uv_default_loop(),
-        &baton->request, Work_Open, Work_AfterOpen);
+        &baton->request, Work_Open, (uv_after_work_cb)Work_AfterOpen);
     assert(status == 0);
 }
 
@@ -221,7 +221,7 @@ void Database::Work_BeginClose(Baton* baton) {
 
     baton->db->RemoveCallbacks();
     int status = uv_queue_work(uv_default_loop(),
-        &baton->request, Work_Close, Work_AfterClose);
+        &baton->request, Work_Close, (uv_after_work_cb)Work_AfterClose);
     assert(status == 0);
 }
 
@@ -500,7 +500,7 @@ void Database::Work_BeginExec(Baton* baton) {
     assert(baton->db->handle);
     assert(baton->db->pending == 0);
     int status = uv_queue_work(uv_default_loop(),
-        &baton->request, Work_Exec, Work_AfterExec);
+        &baton->request, Work_Exec, (uv_after_work_cb)Work_AfterExec);
     assert(status == 0);
 }
 
@@ -569,7 +569,7 @@ void Database::Work_BeginLoadExtension(Baton* baton) {
     assert(baton->db->handle);
     assert(baton->db->pending == 0);
     int status = uv_queue_work(uv_default_loop(),
-        &baton->request, Work_LoadExtension, Work_AfterLoadExtension);
+        &baton->request, Work_LoadExtension, (uv_after_work_cb)Work_AfterLoadExtension);
     assert(status == 0);
 }
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -136,7 +136,7 @@ const char* sqlite_authorizer_string(int type);
     baton->stmt->locked = true;                                                \
     baton->stmt->db->pending++;                                                \
     int status = uv_queue_work(uv_default_loop(),                              \
-        &baton->request, Work_##type, Work_After##type);                       \
+        &baton->request, Work_##type, (uv_after_work_cb)Work_After##type);                       \
     assert(status == 0);
 
 #define STATEMENT_INIT(type)                                                   \

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -118,7 +118,7 @@ void Statement::Work_BeginPrepare(Database::Baton* baton) {
     assert(baton->db->open);
     baton->db->pending++;
     int status = uv_queue_work(uv_default_loop(),
-        &baton->request, Work_Prepare, Work_AfterPrepare);
+        &baton->request, Work_Prepare, (uv_after_work_cb)Work_AfterPrepare);
     assert(status == 0);
 }
 


### PR DESCRIPTION
Updates to work with node 0.10, adding casts to reflect changes in callback prototypes in libuv and updating the dependencies.
