### PR TITLE
add gyp post-build action to move module out of build folder

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,15 @@
 {
+  'conditions': [
+      ['OS=="win"', {
+        'variables': {
+          'copy_command%': 'copy'
+        },
+      },{
+        'variables': {
+          'copy_command%': 'cp'
+        },
+      }]
+  ],
   'targets': [
     {
       'target_name': 'node_sqlite3',
@@ -9,6 +20,23 @@
       ],
       'dependencies': [
         'deps/sqlite3/binding.gyp:sqlite3'
+      ]
+    },
+    {
+      'target_name': 'action_after_build',
+      'type': 'none',
+      'dependencies': [ 'node_sqlite3' ],
+      'actions': [
+        {
+          'action_name': 'move_node_module',
+          'inputs': [
+            '<@(PRODUCT_DIR)/node_sqlite3.node'
+          ],
+          'outputs': [
+            'lib/node_sqlite3.node'
+          ],
+          'action': ['<@(copy_command)', '<@(PRODUCT_DIR)/node_sqlite3.node', 'lib/node_sqlite3.node']
+        }
       ]
     }
   ]

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -1,4 +1,4 @@
-var sqlite3 = module.exports = exports = require('../build/Release/node_sqlite3.node');
+var sqlite3 = module.exports = exports = require('./node_sqlite3.node');
 var path = require('path');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;


### PR DESCRIPTION
This change uses a gyp post-build action to move, in a cross-platform way, the final `node-sqlite3.node` module into the `lib/` folder.

Advantages of this:
- Fixes builds against a node built in debug, that end up in `build/Debug`. Currently in this case the require simply fails because it is hardcoded to `build/Release/node_sqlite3.node`.
- Allows the entire `build` directory to be removed after a successful build - the value of this is for saving room for later packaging. The intermediate object files inside the build directory are often much larger than the final linked module. The alternative of selectively deleting all files and folders inside of `build/` that are not needed at runtime but this is quite is tedious and error prone.
