### PR TITLE
Don't bother unpacking sqlite if we're not using it

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,17 +20,21 @@
     {
       'target_name': 'action_before_build',
       'type': 'none',
-      'actions': [
-        {
-          'action_name': 'unpack_sqlite_dep',
-          'inputs': [
-            './deps/sqlite-autoconf-<@(sqlite_version).tar.gz'
-          ],
-          'outputs': [
-            './deps/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
-          ],
-          'action': ['<@(bin_name)','./node_modules/.bin/targz','deps/sqlite-autoconf-<@(sqlite_version).tar.gz','-x','deps/']
-        }
+      'conditions': [
+        ['sqlite == "internal"', {
+          'actions': [
+            {
+              'action_name': 'unpack_sqlite_dep',
+              'inputs': [
+                './deps/sqlite-autoconf-<@(sqlite_version).tar.gz'
+              ],
+              'outputs': [
+                './deps/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
+              ],
+              'action': ['<@(bin_name)','./node_modules/.bin/targz','deps/sqlite-autoconf-<@(sqlite_version).tar.gz','-x','deps/']
+            }
+          ]
+        }]
       ]
     },
     {


### PR DESCRIPTION
This also helps with packaging, where the dependencies have to be removed early on to make sure there is no risk of the internal versions being used.
