### PR TITLE
Extend the timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     },
     "scripts": {
         "pretest":"make db",
-        "test": "mocha -R spec --timeout 10000"
+        "test": "mocha -R spec --timeout 200000"
     },
     "licenses": [{ "type": "BSD" }],
     "main": "./lib/sqlite3"


### PR DESCRIPTION
I've just noticed that `test/parallel_insert.test.js` took 134383ms to pass on 2.2GHz single-core Pentium 4 in Windows XP.

I guess the timeout should be extended to 200 seconds (currently 10 seconds) or that test should perform less than 1000 inserts.
