### PR TITLE
Drop step@0.0.4 from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "url": "git://github.com/developmentseed/node-sqlite3.git"
     },
     "devDependencies": {
-        "step": "0.0.4",
         "mocha": "1.12.x"
     },
     "engines": {


### PR DESCRIPTION
Currently the `devDependencies` value in `package.json` lists `"step": "0.0.4"`, but it does not seem that the `step` module is used anywhere.

The time has probably come to drop this line.
