### PR TITLE
run test/support/createdb.js before testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "node": ">= 0.6.13 && < 0.11.0"
     },
     "scripts": {
+        "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 200000"
     },
     "licenses": [{ "type": "BSD" }],


### PR DESCRIPTION
Added a line to `package.json` to fix #169 on Windows.
