### PR TITLE
drop devDependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
         "type": "git",
         "url": "git://github.com/developmentseed/node-sqlite3.git"
     },
-    "devDependencies": {
-        "mocha": "1.12.x"
-    },
     "engines": {
         "node": ">= 0.6.13 && < 0.11.0"
     },


### PR DESCRIPTION
The `README.md` file says that `npm install mocha` is necessary for testing, and I suppose that's quite enough.

If some brave person attempts to run `npm install sqlite3 --dev` from the very beginning, then not only the necessary mocha module is installed for sqlite3, but also mocha's own devDependencies are installed.

Recursively.

First of all, that's a lot of garbage.

Some of those devDependencies also fail to install on Windows, generating cryptic errors.

For example, this one recommends to obtain root/Administrator permissions, though I already have them and thus I may guess the problem is somewhere else:

![(screenshot)](https://f.cloud.github.com/assets/1088720/803013/12d2a4cc-ede1-11e2-9669-5bb34b5ce7c0.png)

Even without looking through the whole 1.5 Mb of the npm debug log, I believe that `devDependencies` in `package.json` is not necessary. Here's a pull request to drop it.

(If you have some reason to keep the `1.12.x` bit for mocha, then edit `README.md` and tell people to run `npm install mocha@1.12.x` instead of simple `npm install mocha`.)
