### PR TITLE
display npm package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 node-sqlite3 - Asynchronous, non-blocking [SQLite3](http://sqlite.org/) bindings for [node.js](https://github.com/joyent/node) 0.2-0.4 (versions 2.0.x), **0.6.13+, 0.8.x, and 0.10.x** (versions 2.1.x).
 
 [![Build Status](https://travis-ci.org/developmentseed/node-sqlite3.png?branch=master)](https://travis-ci.org/developmentseed/node-sqlite3)
+[![npm package version](https://badge.fury.io/js/sqlite3.png)](https://npmjs.org/package/sqlite3)
 
 
 # USAGE


### PR DESCRIPTION
The https://badge.fury.io/ service is used to display the latest version of the project's npm package.

A quick look at the GitHub's project page may then tell any user if an upgrade is available (without visiting https://npmjs.org/package/sqlite3 manually for this purpose).

A hyperlink to https://npmjs.org/package/sqlite3 is still available so that the package's version can be confirmed whenever the user feels that https://badge.fury.io/ service is less trusted (or if https://badge.fury.io/ is simply down, though the latter I haven't experienced yet).
