### PR TITLE
added a section that explains rebuilding sqlite3 for node-webkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 node-sqlite3 - Asynchronous, non-blocking [SQLite3](http://sqlite.org/) bindings for [Node.js](http://nodejs.org/) 0.2-0.4 (versions 2.0.x), **0.6.13+, 0.8.x, and 0.10.x** (versions 2.1.x).
 
-(Can also run in [node-webkit](https://github.com/rogerwang/node-webkit) when it uses a supported version of Node's engine.)
+(Can also run in [node-webkit](https://github.com/rogerwang/node-webkit) if it uses a supported version of Node's engine.)
 
 [![Build Status](https://travis-ci.org/developmentseed/node-sqlite3.png?branch=master)](https://travis-ci.org/developmentseed/node-sqlite3)
 [![npm package version](https://badge.fury.io/js/sqlite3.png)](https://npmjs.org/package/sqlite3)


### PR DESCRIPTION
There is an engine called “[node-webkit](https://github.com/rogerwang/node-webkit)”. It allows to `require()` and use Node modules from the context of WebKit-based web browser's windows, and thus the methods of web development can be used to compose cross-platform GUI applications (for Windows, for Mac, for Linux) in JavaScript.

Quite fortunately, node-sqlite3 may run on both engines (Node.js and node-webkit) without any changes in the module's source code.

However, the ABI of Node.js and node-webkit are different, and thus the module has to be rebuilt (using nw-gyp instead of node-gyp) before it is used in node-webkit.

This pull request extends `README.md` and explains such a rebuilding.
