### PR TITLE
Reduce the size of the NPM distribution by ignoring unneeded files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+deps/
+test/
+benchmark/


### PR DESCRIPTION
The files in the `deps/`, `test/` and `benchmark/` directories are quite large, and as far as I can tell, aren't used once the code is packaged for npm.  They can be left out of the npm tarball with this addition.
