### PR TITLE
Functions of Database and Statement should be domain-aware

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -22,7 +22,7 @@ function inherits(target, source) {
 
 sqlite3.cached = {
     Database: function(file, a, b) {
-        EventEmitter.call(this)
+        EventEmitter.call(this);
 
         if (file === '' || file === ':memory:') {
             // Don't cache special databases.
@@ -84,28 +84,20 @@ Database.prototype.exec = function(sql) {
 // Database#prepare(sql, [bind1, bind2, ...], [callback])
 Database.prototype.prepare = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
-    var statement;
 
     if (!params.length || (params.length === 1 && typeof params[0] === 'function')) {
-        statement = new Statement(this, sql, params[0]);
+        return new Statement(this, sql, params[0]);
     }
     else {
-        statement = new Statement(this, sql, errorCallback(params));
-        statement = statement.bind.apply(statement, params);
+        var statement = new Statement(this, sql, errorCallback(params));
+        return statement.bind.apply(statement, params);
     }
-
-    statement.domain = process.domain;
-
-    return statement
 };
 
 // Database#run(sql, [bind1, bind2, ...], [callback])
 Database.prototype.run = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
-
-    statement.domain = process.domain;
-
     statement.run.apply(statement, params).finalize();
     return this;
 };
@@ -114,9 +106,6 @@ Database.prototype.run = function(sql) {
 Database.prototype.get = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
-
-    statement.domain = process.domain;
-
     statement.get.apply(statement, params).finalize();
     return this;
 };
@@ -125,9 +114,6 @@ Database.prototype.get = function(sql) {
 Database.prototype.all = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
-
-    statement.domain = process.domain;
-
     statement.all.apply(statement, params).finalize();
     return this;
 };
@@ -136,9 +122,6 @@ Database.prototype.all = function(sql) {
 Database.prototype.each = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
-
-    statement.domain = process.domain;
-
     statement.each.apply(statement, params).finalize();
     return this;
 };
@@ -146,9 +129,6 @@ Database.prototype.each = function(sql) {
 Database.prototype.map = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
-
-    statement.domain = process.domain;
-
     statement.map.apply(statement, params).finalize();
     return this;
 };

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -22,6 +22,8 @@ function inherits(target, source) {
 
 sqlite3.cached = {
     Database: function(file, a, b) {
+        EventEmitter.call(this)
+
         if (file === '' || file === ':memory:') {
             // Don't cache special databases.
             return new Database(file, a, b);
@@ -60,20 +62,28 @@ inherits(Statement, EventEmitter);
 // Database#prepare(sql, [bind1, bind2, ...], [callback])
 Database.prototype.prepare = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
+    var statement;
 
     if (!params.length || (params.length === 1 && typeof params[0] === 'function')) {
-        return new Statement(this, sql, params[0]);
+        statement = new Statement(this, sql, params[0]);
     }
     else {
-        var statement = new Statement(this, sql, errorCallback(params));
-        return statement.bind.apply(statement, params);
+        statement = new Statement(this, sql, errorCallback(params));
+        statement = statement.bind.apply(statement, params);
     }
+
+    statement.domain = process.domain;
+
+    return statement
 };
 
 // Database#run(sql, [bind1, bind2, ...], [callback])
 Database.prototype.run = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
+
+    statement.domain = process.domain;
+
     statement.run.apply(statement, params).finalize();
     return this;
 };
@@ -82,6 +92,9 @@ Database.prototype.run = function(sql) {
 Database.prototype.get = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
+
+    statement.domain = process.domain;
+
     statement.get.apply(statement, params).finalize();
     return this;
 };
@@ -90,6 +103,9 @@ Database.prototype.get = function(sql) {
 Database.prototype.all = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
+
+    statement.domain = process.domain;
+
     statement.all.apply(statement, params).finalize();
     return this;
 };
@@ -98,6 +114,9 @@ Database.prototype.all = function(sql) {
 Database.prototype.each = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
+
+    statement.domain = process.domain;
+
     statement.each.apply(statement, params).finalize();
     return this;
 };
@@ -105,6 +124,9 @@ Database.prototype.each = function(sql) {
 Database.prototype.map = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);
     var statement = new Statement(this, sql, errorCallback(params));
+
+    statement.domain = process.domain;
+
     statement.map.apply(statement, params).finalize();
     return this;
 };

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -59,6 +59,28 @@ var Statement = sqlite3.Statement;
 inherits(Database, EventEmitter);
 inherits(Statement, EventEmitter);
 
+// Managed counterpart of Database::new
+Database.prototype._init = function() {
+    EventEmitter.call(this);
+};
+
+// Managed counterpart of Statement::new
+Statement.prototype._init = function() {
+    EventEmitter.call(this);
+};
+
+var nativeExec = Database.prototype.exec;
+// Database#exec(sql, [callback])
+Database.prototype.exec = function(sql) {
+    var params = arguments;
+    if (process.domain && params.length === 2 && typeof params[1] === 'function') {
+        params = Array.prototype.slice.call(params,0);
+        // Make sure the callback is called in the current domain.
+        params[1] = process.domain.bind(params[1]);
+    }
+    return nativeExec.apply(this,params);
+};
+
 // Database#prepare(sql, [bind1, bind2, ...], [callback])
 Database.prototype.prepare = function(sql) {
     var params = Array.prototype.slice.call(arguments, 1);

--- a/src/database.cc
+++ b/src/database.cc
@@ -134,6 +134,9 @@ Handle<Value> Database::New(const Arguments& args) {
     OpenBaton* baton = new OpenBaton(db, callback, *filename, mode);
     Work_BeginOpen(baton);
 
+    Handle<Value> argv[0];
+    MakeCallback(args.This(),"_init",0,argv);
+
     return args.This();
 }
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,5 +1,6 @@
 #ifndef NODE_SQLITE3_SRC_MACROS_H
 #define NODE_SQLITE3_SRC_MACROS_H
+#include <node_version.h>
 
 const char* sqlite_code_string(int code);
 const char* sqlite_authorizer_string(int type);
@@ -114,8 +115,18 @@ const char* sqlite_authorizer_string(int type);
         argc, argv                                                             \
     );
 
+#if NODE_VERSION_AT_LEAST(0,8,0)
 #define TRY_CATCH_CALL(context, callback, argc, argv)                          \
 {   MakeCallback(context, callback, argc, argv);                               }
+#else
+#define TRY_CATCH_CALL(context, callback, argc, argv)                          \
+{   TryCatch try_catch;                                                        \
+    (callback)->Call((context), (argc), (argv));                               \
+    if (try_catch.HasCaught()) {                                               \
+        FatalException(try_catch);                                             \
+    }                                                                          }
+#endif
+
 
 #define WORK_DEFINITION(name)                                                 \
     static Handle<Value> name(const Arguments& args);                          \

--- a/src/macros.h
+++ b/src/macros.h
@@ -115,11 +115,7 @@ const char* sqlite_authorizer_string(int type);
     );
 
 #define TRY_CATCH_CALL(context, callback, argc, argv)                          \
-{   TryCatch try_catch;                                                        \
-    (callback)->Call((context), (argc), (argv));                               \
-    if (try_catch.HasCaught()) {                                               \
-        FatalException(try_catch);                                             \
-    }                                                                          }
+{   MakeCallback(context, callback, argc, argv);                               }
 
 #define WORK_DEFINITION(name)                                                 \
     static Handle<Value> name(const Arguments& args);                          \

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -112,6 +112,9 @@ Handle<Value> Statement::New(const Arguments& args) {
     baton->sql = std::string(*String::Utf8Value(sql));
     db->Schedule(Work_BeginPrepare, baton);
 
+    Handle<Value> argv[0];
+    MakeCallback(args.This(),"_init",0,argv);
+
     return args.This();
 }
 

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -1,6 +1,23 @@
 var sqlite3 = require('sqlite3');
 var assert = require('assert');
-var domain = require('domain');
+var shouldSkip = false;
+var domain;
+
+try {
+  domain = require('domain');
+} catch (e) {
+  shouldSkip = true;
+}
+
+
+if(shouldSkip) {
+  exports['skipping domain tests'] = function(beforeExit) {
+    beforeExit(function() {
+
+    });
+  };
+  return;
+}
 
 if (process.setMaxListeners) process.setMaxListeners(0);
 

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -1,0 +1,90 @@
+var sqlite3 = require('sqlite3');
+var assert = require('assert');
+var domain = require('domain');
+
+if (process.setMaxListeners) process.setMaxListeners(0);
+
+var protect = function(fn) {
+  return function(beforeExit) {
+    var oldListeners = process.listeners('uncaughtException').splice(0);
+
+    oldListeners.filter(function(fn) {
+      // XXX: This is a bit of a hack:
+      // we know the name of the function that
+      // the domain module adds as a listener
+      // for `uncaughtException`, and we want
+      // that to remain available -- but we
+      // don't want expresso's uncaughtHandler
+      // to be fired as well.
+      return fn.name === 'uncaughtHandler'
+    }).forEach(function(fn) {
+      process.on('uncaughtException', fn)
+    })
+
+    var realBeforeExit;
+    var injectBeforeExit = function(fn) {
+          realBeforeExit = fn;
+        };
+
+    beforeExit(function() {
+      var listeners = process.listeners('uncaughtException');
+
+      // put expresso's uncaughtException handler
+      // back in place.
+      listeners.splice.apply(
+        listeners, [0, listeners.length].concat(oldListeners)
+      ); 
+
+      // call the real `beforeExit` function defined
+      // by the test, if any.
+      if (realBeforeExit) {
+        realBeforeExit();
+      }
+    })
+
+    fn(injectBeforeExit);
+  };
+}
+
+var testStatementMethod = function(method) {
+  return function(beforeExit) {
+    var dom = domain.create();
+    var db = new sqlite3.Database(':memory:');
+    var caughtCount = 0;
+    var expected = 1 + ~~(Math.random() * 10);
+
+    dom.on('error', function(err) {
+      ++caughtCount;
+    });
+
+    dom.run(function() {
+      db[method]('garbled nonsense', function(err) {
+        // set a timeout, so that we ensure that the
+        // domain chain gets passed along.
+
+        for (var i = 0; i < expected; ++i) {
+          setTimeout(function() {
+            if (err) {
+              throw err;
+            }
+          }, 0);
+        }
+      });
+    });
+
+    beforeExit(function() {
+      assert.equal(caughtCount, expected);
+    });
+  };
+}
+
+exports['test Database#run works with domains'] = protect(testStatementMethod('run'));
+exports['test Database#prepare works with domains'] = protect(testStatementMethod('prepare'));
+exports['test Database#get works with domains'] = protect(testStatementMethod('get'));
+exports['test Database#map works with domains'] = protect(testStatementMethod('all'));
+exports['test Database#each works with domains'] = protect(testStatementMethod('each'));
+exports['test Database#map works with domains'] = protect(testStatementMethod('map'));
+
+
+
+

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -31,10 +31,10 @@ describe('profiling', function() {
         assert.ok(!create);
         db.run("CREATE TABLE foo (id int)", function(err) {
             if (err) throw err;
-            process.nextTick(function() {
+            setTimeout(function() {
                 assert.ok(create);
                 done();
-            });
+            },10);
         });
     });
 
@@ -43,10 +43,10 @@ describe('profiling', function() {
         assert.ok(!select);
         db.run("SELECT * FROM foo", function(err) {
             if (err) throw err;
-            process.nextTick(function() {
+            setTimeout(function() {
                 assert.ok(select);
                 done();
-            });
+            },10);
         });
     });
 


### PR DESCRIPTION
This is based on a earlier pull request that became stale a year ago: https://github.com/mapbox/node-sqlite3/pull/81

It is about NodeJS domains: http://nodejs.org/api/domain.html

At the moment callbacks from Database and Statement are not domain-aware. That means that when a call was made from within a domain, the callback of that call won't be in that same domain. Exceptions that are thrown inside such a callback will be caught by process.on('uncaughtException') instead of domain.on('error'). This can be confusing for developers that make use of domains for exceptions or logging.

I used the commits from @chrisdickinson as a base and converted the test to Mocha.
I've also incorporated the comments from the mentioned pull request, which basically said to make use of EventEmitter to set domain, instead of manually setting the domain. To do this I had to call back to JS from the native Database/Statement C++ constructors.
Database#exec is not implemented using Statement, so the callback for that function needed to be wrapped in order to pass the domain.

Side note:
This is a step in the right direction I think, but this doesn't make everything of node-sqlite3 domain-aware. The calls in Statement are purely native and I wasn't sure how to store and bind the domain to the callback. This is however quite easy if these functions were wrapped in a Javascript. Database#exec is an example for that.
That said, problems/confusion will only arise once a statement is created in one domain (A), but the statement is used in another (B). You would think callbacks will be in domain B, but they will be in domain A with these commits.
