### PR TITLE
fix db opening error with absolute path on windows

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -26,9 +26,7 @@ sqlite3.cached = {
             return new Database(file, a, b);
         }
 
-        if (file[0] !== '/') {
-            file = path.join(process.cwd(), file);
-        }
+        file = path.resolve(file);
 
         if (!sqlite3.cached.objects[file]) {
             var db =sqlite3.cached.objects[file] = new Database(file, a, b);


### PR DESCRIPTION
fix #282 (SQLITE_CANTOPEN error when cached.Database is called with absolute path on windows).

---

Creating db using cached.Database with absolute path has error on windows.
below is my code and error message

code

```
var sqlite = require('sqlite3');
var current_db = new sqlite.cached.Database('current.db');    // OK
var relative_db = new sqlite.cached.Database('folder\\current.db');    // OK
var absolute_db = new sqlite.cached.Database('C:\\current.db');    // ERROR!!!
```

error message

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: SQLITE_CANTOPEN: unable to open database file
```
