### PR TITLE
Fix leak in complete() callback of Database.each()

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -122,10 +122,14 @@ public:
     struct Async;
 
     struct EachBaton : Baton {
-        EachBaton(Statement* stmt_, Handle<Function> cb_) :
-            Baton(stmt_, cb_) {}
         Persistent<Function> completed;
         Async* async; // Isn't deleted when the baton is deleted.
+
+        EachBaton(Statement* stmt_, Handle<Function> cb_) :
+            Baton(stmt_, cb_) {}
+        virtual ~EachBaton() {
+            NanDisposePersistent(completed);
+        }
     };
 
     struct PrepareBaton : Database::Baton {


### PR DESCRIPTION
Add destructor to EachBaton that disposes the `completed` callback function.

Fixes #297.

I didn't implement the part of my previous patch that prevented the duplication of the callback handles in `Statement::Work_BeginEach` because 1. it's not strictly necessary and 2. I don't understand enough of this nan stuff to be confident to do it right.

I've checked (using node v0.10.22) that 1. the memory leak still exists in current HEAD and 2. this patch fixes it.
