### PR TITLE
[Suggestion] Use NPM features to ensure correct node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
         "aws-sdk": "~2.0.4"
     },
     "engines": {
-        "node": ">= 0.8.0 < 0.13.0"
+        "node": ">= 0.8.0 < 0.11.0 || >= 0.11.13 < 0.13.0"
     },
+    "engineStrict": true,
     "scripts": {
         "install": "node-pre-gyp install --fallback-to-build",
         "pretest": "node test/support/createdb.js",


### PR DESCRIPTION
According to the readme: 

> The sqlite3 module works with Node.js v0.8.x, v0.10.x or v0.11.x (though only v0.11.13 and above).

Just a suggestion that the engines parameter be updated to be more specific, and that `engineStrict:true` is provided so that the node version should be enforced by npm when running `npm install` (https://www.npmjs.org/doc/files/package.json.html#enginestrict)
