### PR TITLE
Use a looser semver for node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "nan": "1.3.0",
-        "node-pre-gyp": "0.5.27"
+        "node-pre-gyp": "~0.5.27"
     },
     "bundledDependencies": [
         "node-pre-gyp"


### PR DESCRIPTION
Main motivation: allow downstream installs to `npm dedupe` effectively post-install.

https://github.com/mapbox/mapbox-studio/issues/611#issuecomment-57152761

cc @springmeyer 
