### PR TITLE
fix make binding.gyp compatible with node-gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -2,11 +2,12 @@
   "includes": [ "deps/common-sqlite.gypi" ],
   "variables": {
       "sqlite%":"internal",
-      "sqlite_libname%":"sqlite3"
+      "sqlite_libname%":"sqlite3",
+      "module_path%":"lib/binding"
   },
   "targets": [
     {
-      "target_name": "<(module_name)",
+      "target_name": "node_sqlite3",
       "include_dirs": ["<!(node -e \"require('nan')\")"],
       "conditions": [
         ["sqlite != 'internal'", {
@@ -40,10 +41,10 @@
     {
       "target_name": "action_after_build",
       "type": "none",
-      "dependencies": [ "<(module_name)" ],
+      "dependencies": [ "node_sqlite3" ],
       "copies": [
           {
-            "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+            "files": [ "<(PRODUCT_DIR)/node_sqlite3.node" ],
             "destination": "<(module_path)"
           }
       ]


### PR DESCRIPTION
Instead of just node-pre-gyp.

The binding.gyp in current master isn't compatible with node-gyp without manual editing. (AFAIK)

BTW I'm interested in this, because this allows for automated building for atom-shell with node-gyp.
(typo in the commit msg where it says nw-gyp)
