### PR TITLE
Fix non-x86 build failure.

### DIFF
--- a/src/gcc-preinclude.h
+++ b/src/gcc-preinclude.h
@@ -1,4 +1,6 @@
 
 // https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
 
+#if defined(__x86_64__)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#endif


### PR DESCRIPTION
The inclusion of gcc-preinclude.h breaks the build on ARM because of
the missing .symver symbol.  Only define it on x86.

Closes out mapbox/node-sqlite3#445.