### PR TITLE
Fix non-Linux build failure.

### DIFF
--- a/src/gcc-preinclude.h
+++ b/src/gcc-preinclude.h
@@ -1,6 +1,6 @@
 
 // https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
 
-#if defined(__x86_64__)
+#if defined(__linux__) && defined(__x86_64__)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 #endif


### PR DESCRIPTION
gcc-preinclude.h contains a fix for old Linux systems but it's included
unconditionally on other platforms as well.

I could update the GYP files to exclude it on other platforms but it
seems easier to add a `defined(__linux__)` guard to the header file.

Let this be the last fix.

Refs #445.  R=@springmeyer?