### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,7 @@
         "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 480000"
     },
-    "licenses": [
-        {
-            "type": "BSD"
-        }
-    ],
+    "license": "BSD-3-Clause",
     "keywords": [
         "sql",
         "sqlite",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/