### PR TITLE
unpacked iojs tar file ends with -ia32 and not -x86

### DIFF
--- a/scripts/build_against_node.sh
+++ b/scripts/build_against_node.sh
@@ -55,7 +55,7 @@ if [[ $(uname -s) == 'Linux' ]]; then
         wget https://iojs.org/download/release/${NVER}/iojs-${NVER}-${platform}-x86.tar.gz
         tar xf iojs-${NVER}-${platform}-x86.tar.gz
         # enable 32 bit iojs
-        export PATH=$(pwd)/iojs-${NVER}-${platform}-x86/bin:$PATH
+        export PATH=$(pwd)/iojs-${NVER}-${platform}-ia32/bin:$PATH
     else
         wget http://nodejs.org/dist/${NVER}/node-${NVER}-${platform}-x86.tar.gz
         tar xf node-${NVER}-${platform}-x86.tar.gz


### PR DESCRIPTION
Noticed this while playing around with your build scripts. Using them as inspiration for `leveldown`.