### PR TITLE
Remove memcpy@@GLIBC_2.14 workaround.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,6 @@
         }
         ]
       ],
-      "cflags": [ "-include ../src/gcc-preinclude.h" ],
       "sources": [
         "src/database.cc",
         "src/node_sqlite3.cc",

--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -71,7 +71,6 @@
       'dependencies': [
         'action_before_build'
       ],
-      'cflags': [ '-include ../src/gcc-preinclude.h' ],
       'sources': [
         '<(SHARED_INTERMEDIATE_DIR)/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
       ],
@@ -85,7 +84,6 @@
       },
       'cflags_cc': [
           '-Wno-unused-value',
-          '-include ../src/gcc-preinclude.h'
       ],
       'defines': [
         '_REENTRANT=1',

--- a/src/gcc-preinclude.h
+++ b/src/gcc-preinclude.h
@@ -1,6 +1,0 @@
-
-// https://rjpower9000.wordpress.com/2012/04/09/fun-with-shared-libraries-version-glibc_2-14-not-found/
-
-#if defined(__linux__) && defined(__x86_64__)
-__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
-#endif

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -288,8 +288,8 @@ bool Statement::Bind(const Parameters & parameters) {
                 } break;
                 case SQLITE_BLOB: {
                     status = sqlite3_bind_blob(_handle, pos,
-                        ((Values::Blob*)field)->value,
-                        ((Values::Blob*)field)->length, SQLITE_TRANSIENT);
+                        ((Values::Blob*)field)->data.data(),
+                        ((Values::Blob*)field)->data.size(), SQLITE_TRANSIENT);
                 } break;
                 case SQLITE_NULL: {
                     status = sqlite3_bind_null(_handle, pos);
@@ -769,7 +769,9 @@ Local<Object> Statement::RowToJS(Row* row) {
                 value = NanNew<String>(((Values::Text*)field)->value.c_str(), ((Values::Text*)field)->value.size());
             } break;
             case SQLITE_BLOB: {
-                value = NanNew(NanNewBufferHandle(((Values::Blob*)field)->value, ((Values::Blob*)field)->length));
+                value = NanNew(NanNewBufferHandle(
+                      ((Values::Blob*)field)->data.data(),
+                      ((Values::Blob*)field)->data.size()));
             } break;
             case SQLITE_NULL: {
                 value = NanNew(NanNull());

--- a/src/statement.h
+++ b/src/statement.h
@@ -52,15 +52,10 @@ namespace Values {
 
     struct Blob : Field {
         template <class T> inline Blob(T _name, size_t len, const void* val) :
-                Field(_name, SQLITE_BLOB), length(len) {
-            value = (char*)malloc(len);
-            memcpy(value, val, len);
-        }
-        inline ~Blob() {
-            free(value);
-        }
-        int length;
-        char* value;
+            Field(_name, SQLITE_BLOB),
+            data(static_cast<const char*>(val),
+                 static_cast<const char*>(val) + len) {}
+        std::vector<char> data;
     };
 
     typedef Field Null;


### PR DESCRIPTION
There is only one place in the code base that uses memcpy().  Simply
rewrite it to not depend on mempcy() and drop the symver hack.

Fixes: https://github.com/mapbox/node-sqlite3/issues/459

R=@springmeyer