### PR TITLE
Add support for sqlite3_interrupt

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -104,6 +104,7 @@ protected:
         _handle(NULL),
         open(false),
         locked(false),
+        closing(false),
         pending(0),
         serialize(false),
         debug_trace(NULL),
@@ -151,6 +152,8 @@ protected:
 
     static NAN_METHOD(Configure);
 
+    static NAN_METHOD(Interrupt);
+
     static void SetBusyTimeout(Baton* baton);
 
     static void RegisterTraceCallback(Baton* baton);
@@ -171,6 +174,7 @@ protected:
     sqlite3* _handle;
 
     bool open;
+    bool closing;
     bool locked;
     unsigned int pending;
 

--- a/test/interrupt.test.js
+++ b/test/interrupt.test.js
@@ -1,0 +1,69 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+
+describe('interrupt', function() {
+    it('should interrupt queries', function(done) {
+        var query =
+            'with t (n) as (values (1),(2),(3),(4),(5),(6),(7),(8)) ' +
+            'select last.n ' +
+            'from t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t as last';
+
+        var interrupted = false;
+        var saved = null;
+
+        var db = new sqlite3.Database(':memory:', function() {
+            db.each(query, function(err) {
+                if (!interrupted) {
+                    interrupted = true;
+                    db.interrupt();
+                } else if (err) {
+                    saved = err;
+                }
+            });
+
+            db.close(function() {
+                if (saved) {
+                    assert.equal(saved.message, 'SQLITE_INTERRUPT: interrupted');
+                    assert.equal(saved.errno, sqlite3.INTERRUPT);
+                    assert.equal(saved.code, 'SQLITE_INTERRUPT');
+                    done();
+                } else {
+                    done(new Error('Completed query without error, but expected error'));
+                }
+            });
+        });
+    });
+
+    it('should throw if interrupt is called before open', function(done) {
+        var db = new sqlite3.Database(':memory:');
+
+        assert.throws(function() {
+            db.interrupt();
+        }, (/Database is not open/));
+
+        db.close();
+        done();
+    });
+
+    it('should throw if interrupt is called after close', function(done) {
+        var db = new sqlite3.Database(':memory:');
+
+        db.close(function() {
+            assert.throws(function() {
+                db.interrupt();
+            }, (/Database is not open/));
+
+            done();
+        });
+    });
+
+    it('should throw if interrupt is called during close', function(done) {
+        var db = new sqlite3.Database(':memory:', function() {
+            db.close();
+            assert.throws(function() {
+                db.interrupt();
+            }, (/Database is closing/));
+            done();
+        });
+    });
+});


### PR DESCRIPTION
This change adds support for [sqlite3_interrupt](https://www.sqlite.org/c3ref/interrupt.html). This makes it possible to interrupt a long running query.

I called the function synchronously instead of going through `db->Schedule` because if it was scheduled it wouldn't be possible to interrupt `exec`. This is because while `exec` is running the work queue is not processed. Also, the `sqlite3_interrupt` function doesn't do any I/O or acquire any locks, so it won't block the javascript thread.

The downside of calling `sqlite3_interrupt` synchronously means that it has to check whether the database is open, and has to check that `sqlite3_close` is not about to be run by another thread. Basically, if `sqlite3_interrupt` is called on an already closed database, then it could cause memory corruption.

To avoid this, I added a `closing` variable that's set right before sending a `close` to a worker thread. The `open` variable isn't sufficient because it's only set to `false` after `sqlite3_close` has been called.