### PR TITLE
Upgrade mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "node-pre-gyp"
     ],
     "devDependencies": {
-        "mocha": "1.x",
+        "mocha": "~2.3.3",
         "aws-sdk": "~2.1.26"
     },
     "scripts": {


### PR DESCRIPTION
While running tests, I noticed a deprecation message from node:

    (node) child_process: options.customFds option is deprecated. Use options.stdio instead.

Installing the latest mocha gets rid of it.