### PR TITLE
Updated OS X building section

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Set the location where `brew` installed it:
     npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix`
     
     node -e 'require("sqlite3")'
-
+On some configurations if node-pre-gyp building fails you will need to run `npm install sqlite3` as root (using `sudo`).
 ### On most Linuxes (including Raspberry Pi)
 
 Set the location where `make` installed it:


### PR DESCRIPTION
Updated this because I've got building errors on El Capitan with Node 4.2.1, NPM 3 and node-pre-gyp 0.6.7

See log: 

node-pre-gyp ERR! stack Error: Failed to execute '/Users/getrix/.nvm/versions/node/v4.2.1/bin/node /Users/getrix/.nvm/versions/node/v4.2.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/Volumes/Data HD/Webapps/Hosts/ghostApp/node_modules/sqlite3/lib/binding/node-v46-darwin-x64/node_sqlite3.node --module_name=node_sqlite3 --module_path=/Volumes/Data HD/Webapps/Hosts/ghostApp/node_modules/sqlite3/lib/binding/node-v46-darwin-x64' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/Volumes/Data HD/Webapps/Hosts/ghostApp/node_modules/sqlite3/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:87:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:172:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:818:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
node-pre-gyp ERR! System Darwin 15.0.0
node-pre-gyp ERR! command "/Users/getrix/.nvm/versions/node/v4.2.1/bin/node" "/Volumes/Data HD/Webapps/Hosts/ghostApp/node_modules/sqlite3/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /Volumes/Data HD/Webapps/Hosts/ghostApp/node_modules/sqlite3
node-pre-gyp ERR! node -v v4.2.1
node-pre-gyp ERR! node-pre-gyp -v v0.6.7
node-pre-gyp ERR! not ok