### PR TITLE
Enable json1 extension by default

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -80,6 +80,7 @@
         'defines': [
           'SQLITE_THREADSAFE=1',
           'SQLITE_ENABLE_FTS3',
+          'SQLITE_ENABLE_JSON1',
           'SQLITE_ENABLE_RTREE'
         ],
       },
@@ -91,6 +92,7 @@
         '_REENTRANT=1',
         'SQLITE_THREADSAFE=1',
         'SQLITE_ENABLE_FTS3',
+        'SQLITE_ENABLE_JSON1',
         'SQLITE_ENABLE_RTREE'
       ],
       'export_dependent_settings': [

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -1,0 +1,13 @@
+var sqlite3 = require('..');
+
+describe('json', function() {
+    var db;
+
+    before(function(done) {
+        db = new sqlite3.Database(':memory:', done);
+    });
+
+    it('should select JSON', function(done) {
+        db.run('SELECT json(?)', JSON.stringify({ok:true}), done);
+    });
+});


### PR DESCRIPTION
ref #532

Enables the [JSON1 extension](https://www.sqlite.org/json1.html) added in 3.9.0, and adds a test to confirm the `json()` function exists.
