### PR TITLE
explicitly set platforms for `powershell Install-Product` on AppVeyor

### DIFF
--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -34,9 +34,15 @@ ECHO downloading/installing node
 ::IF /I "%APPVEYOR%"=="True" IF /I "%msvs_toolset%"=="12" powershell Install-Product node $env:nodejs_version $env:Platform
 ::TESTING:
 ::always install (get npm matching node), but delete installed programfiles node.exe afterwards for VS2015 (using custom node.exe)
-IF /I "%APPVEYOR%"=="True" powershell Install-Product node $env:nodejs_version $env:Platform
+IF /I "%APPVEYOR%"=="True" GOTO APPVEYOR_INSTALL
+GOTO SKIP_APPVEYOR_INSTALL
+
+:APPVEYOR_INSTALL
+IF /I "%platform%"=="x64" powershell Install-Product node $env:nodejs_version x64
+IF /I "%platform%"=="x86" powershell Install-Product node $env:nodejs_version x86
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
+:SKIP_APPVEYOR_INSTALL
 IF /I "%msvs_toolset%"=="12" GOTO NODE_INSTALLED
 
 


### PR DESCRIPTION
Seems to work (AppVeyor's [build](https://ci.appveyor.com/project/Mapbox/node-sqlite3/build/1.0.426) is green).

Fixes appveyor/ci#497 (not really, but works around it).

Fixes #549.

Fixes #557.

Might need `git commit --allow-empty -m "[publish binary]"` in a separate branch (or not really empty, but containing only the necessary AppVeyor config, something very similar to 9cdebff97712bf810f1cf96bc700887090db20fc).