### PR TITLE
On Mac OS X, never fall back to waiting 1s to aquire transactions

### DIFF
--- a/deps/common-sqlite.gypi
+++ b/deps/common-sqlite.gypi
@@ -17,6 +17,9 @@
           '-DNDEBUG'
         ],
         'xcode_settings': {
+          'OTHER_CFLAGS': [
+            '-DHAVE_USLEEP=1'
+          ],
           'OTHER_CPLUSPLUSFLAGS!': [
             '-O3',
             '-Os',
@@ -36,6 +39,9 @@
           'NDEBUG'
         ],
         'xcode_settings': {
+          'OTHER_CFLAGS': [
+            '-DHAVE_USLEEP=1'
+          ],
           'OTHER_CPLUSPLUSFLAGS!': [
             '-Os',
             '-O2'


### PR DESCRIPTION
We're building node-sqlite3 against Electron and using it in N1 (http://github.com/nylas/N1). The app opens connections to a sqlite database from several Node processes and we recently discovered that it's waiting intervals of 1000ms to aquire transactions when it encounters `SQLITE_BUSY` because `HAVE_USLEEP` is being erroneously set to false at compile time. (I'm not sure why this is the case—as far as I know, `usleep` has always been available on Mac OS X!)

This PR changes the sqlite gyp config so that `HAVE_USLEEP` is always passed in on Mac OS X. We verified that this corrects our issue in N1 by measuring the wall time it takes to open transactions and observing that it's no longer either `1ms` or `1001ms`.

Given how much compile flags impact sqlite's performance, it might be good to dig in and figure out why this is necessary, and possibly enable it on other platforms via `'cflags': ['-DHAVE_USLEEP=1']`
