### PR TITLE
Add support for sqlite3_interrupt (with fixed test)

### DIFF
--- a/src/database.h
+++ b/src/database.h
@@ -103,6 +103,7 @@ protected:
     Database() : Nan::ObjectWrap(),
         _handle(NULL),
         open(false),
+        closing(false),
         locked(false),
         pending(0),
         serialize(false),
@@ -151,6 +152,8 @@ protected:
 
     static NAN_METHOD(Configure);
 
+    static NAN_METHOD(Interrupt);
+
     static void SetBusyTimeout(Baton* baton);
 
     static void RegisterTraceCallback(Baton* baton);
@@ -171,6 +174,7 @@ protected:
     sqlite3* _handle;
 
     bool open;
+    bool closing;
     bool locked;
     unsigned int pending;
 

--- a/test/interrupt.test.js
+++ b/test/interrupt.test.js
@@ -1,0 +1,75 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+
+describe('interrupt', function() {
+    it('should interrupt queries', function(done) {
+        var interrupted = false;
+        var saved = null;
+
+        var db = new sqlite3.Database(':memory:', function() {
+            db.serialize();
+
+            var setup = 'create table t (n int);';
+            for (var i = 0; i < 8; i += 1) {
+                setup += 'insert into t values (' + i + ');';
+            }
+            db.exec(setup);
+
+            var query = 'select last.n ' +
+                'from t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t as last';
+
+            db.each(query, function(err) {
+                if (err) {
+                    saved = err;
+                } else if (!interrupted) {
+                    interrupted = true;
+                    db.interrupt();
+                }
+            });
+
+            db.close(function() {
+                if (saved) {
+                    assert.equal(saved.message, 'SQLITE_INTERRUPT: interrupted');
+                    assert.equal(saved.errno, sqlite3.INTERRUPT);
+                    assert.equal(saved.code, 'SQLITE_INTERRUPT');
+                    done();
+                } else {
+                    done(new Error('Completed query without error, but expected error'));
+                }
+            });
+        });
+    });
+
+    it('should throw if interrupt is called before open', function(done) {
+        var db = new sqlite3.Database(':memory:');
+
+        assert.throws(function() {
+            db.interrupt();
+        }, (/Database is not open/));
+
+        db.close();
+        done();
+    });
+
+    it('should throw if interrupt is called after close', function(done) {
+        var db = new sqlite3.Database(':memory:');
+
+        db.close(function() {
+            assert.throws(function() {
+                db.interrupt();
+            }, (/Database is not open/));
+
+            done();
+        });
+    });
+
+    it('should throw if interrupt is called during close', function(done) {
+        var db = new sqlite3.Database(':memory:', function() {
+            db.close();
+            assert.throws(function() {
+                db.interrupt();
+            }, (/Database is closing/));
+            done();
+        });
+    });
+});


### PR DESCRIPTION
This reintroduces #518, fixing the test failure that caused it to be reverted in #630. The test failure was happening because the interrupt test used common table expressions, and common table expressions are not supported on older versions of sqlite. I removed the use of common table expressions in the interrupt test to fix it.