### PR TITLE
updated package.json dep semvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
         "url": "git://github.com/mapbox/node-sqlite3.git"
     },
     "dependencies": {
-        "nan": "~2.2.0",
-        "node-pre-gyp": "~0.6.25"
+        "nan": "^2.3.2",
+        "node-pre-gyp": "^0.6.25"
     },
     "bundledDependencies": [
         "node-pre-gyp"
     ],
     "devDependencies": {
-        "mocha": "~2.3.3",
-        "aws-sdk": "~2.1.26"
+        "mocha": "^2.3.3",
+        "aws-sdk": "^2.1.26"
     },
     "scripts": {
         "prepublish":"npm ls",


### PR DESCRIPTION
Depending on outdated packages is causing [some issues](https://github.com/mapbox/node-sqlite3/issues/634). The [current standard](https://nodesource.com/blog/semver-tilde-and-caret/) calls for a more forgiving semver signature like thusly: `"nan": "^2.3.2"`