### PR TITLE
Fix interrupt test: wait for exec to complete before continuing with test

### DIFF
--- a/test/interrupt.test.js
+++ b/test/interrupt.test.js
@@ -13,29 +13,34 @@ describe('interrupt', function() {
             for (var i = 0; i < 8; i += 1) {
                 setup += 'insert into t values (' + i + ');';
             }
-            db.exec(setup);
 
-            var query = 'select last.n ' +
-                'from t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t as last';
-
-            db.each(query, function(err) {
+            db.exec(setup, function(err) {
                 if (err) {
-                    saved = err;
-                } else if (!interrupted) {
-                    interrupted = true;
-                    db.interrupt();
+                    return done(err);
                 }
-            });
 
-            db.close(function() {
-                if (saved) {
-                    assert.equal(saved.message, 'SQLITE_INTERRUPT: interrupted');
-                    assert.equal(saved.errno, sqlite3.INTERRUPT);
-                    assert.equal(saved.code, 'SQLITE_INTERRUPT');
-                    done();
-                } else {
-                    done(new Error('Completed query without error, but expected error'));
-                }
+                var query = 'select last.n ' +
+                    'from t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t,t as last';
+
+                db.each(query, function(err) {
+                    if (err) {
+                        saved = err;
+                    } else if (!interrupted) {
+                        interrupted = true;
+                        db.interrupt();
+                    }
+                });
+
+                db.close(function() {
+                    if (saved) {
+                        assert.equal(saved.message, 'SQLITE_INTERRUPT: interrupted');
+                        assert.equal(saved.errno, sqlite3.INTERRUPT);
+                        assert.equal(saved.code, 'SQLITE_INTERRUPT');
+                        done();
+                    } else {
+                        done(new Error('Completed query without error, but expected error'));
+                    }
+                });
             });
         });
     });


### PR DESCRIPTION
@springmeyer I'm sorry to have broken the build twice and caused so much trouble. The reason that the test failed this time is that `db.exec` does not not block other queries from starting in `db.serialize` mode. This is mentioned in issue #41.

I was using `db.exec` to create a test table `t`. Depending on the order that the worker threads did stuff, that might not have happened before the query that used the table `t` was run. I fixed this by waiting for `db.exec` to complete before continuing with the rest of the test.

Sorry again.