### PR TITLE
Update sqlite3.js: add query attributes to error

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -13,6 +13,9 @@ function normalizeMethod (fn) {
             var callback = args[args.length - 1];
             errBack = function(err) {
                 if (err) {
+                    err.sql = sql;
+                    if (args[0] instanceof Array)
+                        err.params = args[0];
                     callback(err);
                 }
             };


### PR DESCRIPTION
Only db-message is not enough to understand what happened.
For example: db rejected data by one of unnamed constraint. Define triggered constraint without additional info (sql and params) is hard. Currently I use code like below but it's not comfortably.
```
var sql = 'insert into t values (?)';
var params = ['smth'];
db.run(sql, params, function (err) {
    if (err)
        console.log(err, sql, params);
});
```