### PR TITLE
Add `Statement#expandedSql()` to return SQL statement with bound parameters, as a `String` object.

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -206,6 +206,7 @@ public:
     WORK_DEFINITION(Each);
     WORK_DEFINITION(Reset);
 
+    static NAN_METHOD(ExpandedSql);
     static NAN_METHOD(Finalize);
 
 protected:
@@ -229,6 +230,9 @@ protected:
     void Process();
     void CleanQueue();
     template <class T> static void Error(T* baton);
+
+    char* ExpandedSql();
+
 
 protected:
     Database* db;


### PR DESCRIPTION
Hello maintainers of `node-sqlite3`, I have added instance method `expandedSql` for the `Statement` object, which is a wrapper around `sqlite3_expanded_sql` C function.

I noticed that there is already `Statement#sql` as a property. I decided to implement `expandedSql` as an instance method; the actual SQL statement being returned depends on the parameter(s) provided to the last invocation of `Statement#bind`.

Example code:
```js
> // In Node REPL.
> var sq = require('sqlite3')
> // Make sure test.db does not exist; don't clobber existing file.
> var db = new sq.Database('test.db')
> db.run('CREATE TABLE test1 (id INTEGER)')
> var stmt = db.prepare('INSERT INTO test1 (id) VALUES (?)')
> stmt.expandedSql()
'INSERT INTO test1 (id) VALUES (NULL)'
> stmt.bind(2)
> stmt.expandedSql()
'INSERT INTO test1 (id) VALUES (2)'
> stmt.finalize()
> db.close()
```

Thanks for providing this Node module! ☺️ 

CC @springmeyer , @tmcw 