### PR TITLE
Upgrade node-pre-gyp to version 0.6.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "nan": "~2.4.0",
-    "node-pre-gyp": "~0.6.31"
+    "node-pre-gyp": "~0.6.32"
   },
   "bundledDependencies": [		
       "node-pre-gyp"		


### PR DESCRIPTION
The 0.6.32 version of node-pre-gyp supports npm configuration for CA bundles.