### PR TITLE
Add electron builds to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,14 @@ matrix:
      - os: osx
        compiler: clang
        env: NODE_VERSION="0.10" # node abi 11
+     # electron Linux
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="1.6.2"
+       addons:
+         apt:
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.5']
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,13 @@ before_script:
    fi
 
 script:
-- if [[ "${NODE_VERSION}" ]]; then ./scripts/build_against_node.sh; fi;
+- if [[ "${NODE_VERSION}" ]]; then
+    if [[ "${ELECTRON_VERSION}" ]]; then
+      ./scripts/build_against_electron.sh;
+    else
+      ./scripts/build_against_node.sh;
+    fi;
+  fi
 - if [[ "${NODE_VERSION}" -eq "4" ]]; then ./node_modules/.bin/eslint lib; fi;
 # disabled for now: need to port to sudo:false
 #- if [[ "${NODE_WEBKIT}" ]]; then ./scripts/build_against_node_webkit.sh; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,13 @@ matrix:
          apt:
             sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
             packages: [ 'clang-3.5']
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="1.3.14"
+       addons:
+         apt:
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.5']
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,13 +62,13 @@ environment:
       platform: x64
       msvs_toolset: 12
       NODE_RUNTIME: electron
-      NODE_RUNTIME_VERSION: 1.6.3
+      NODE_RUNTIME_VERSION: 1.6.2
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
     - nodejs_version: 6
       platform: x86
       msvs_toolset: 12
       NODE_RUNTIME: electron
-      NODE_RUNTIME_VERSION: 1.6.3
+      NODE_RUNTIME_VERSION: 1.6.2
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
     - nodejs_version: 6
       platform: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,6 +57,10 @@ environment:
       platform: x64
       msvs_toolset: 14
       TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+    - nodejs_version: 6
+      platform: x64
+      msvs_toolset: 12
+      TOOLSET_ARGS: --runtime=electron --target=1.6.0 --dist-url=https://atom.io/download/electron
 
 os: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,24 @@ environment:
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.6.3
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 6
+      platform: x86
+      msvs_toolset: 12
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 1.6.3
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 6
+      platform: x64
+      msvs_toolset: 12
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 1.3.14
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 6
+      platform: x86
+      msvs_toolset: 12
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 1.3.14
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
 
 os: Visual Studio 2015
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,10 +57,13 @@ environment:
       platform: x64
       msvs_toolset: 14
       TOOLSET_ARGS: --dist-url=https://s3.amazonaws.com/mapbox/node-cpp11 --toolset=v140
+    # electron
     - nodejs_version: 6
       platform: x64
       msvs_toolset: 12
-      TOOLSET_ARGS: --runtime=electron --target=1.6.0 --dist-url=https://atom.io/download/electron
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 1.6.3
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
 
 os: Visual Studio 2015
 

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -7,8 +7,8 @@ ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 SET PATH=%CD%;%PATH%
 SET msvs_version=2013
 IF "%msvs_toolset%"=="14" SET msvs_version=2015
-IF NOT "%NODE_RUNTIME%"=="" SET TOOLSET_ARGS="%TOOLSET_ARGS% --runtime=%NODE_RUNTIME%"
-IF NOT "%NODE_RUNTIME_VERSION%"=="" SET TOOLSET_ARGS="%TOOLSET_ARGS% --target=%NODE_RUNTIME_VERSION%"
+IF NOT "%NODE_RUNTIME%"=="" SET "TOOLSET_ARGS=%TOOLSET_ARGS% --runtime=%NODE_RUNTIME%"
+IF NOT "%NODE_RUNTIME_VERSION%"=="" SET "TOOLSET_ARGS=%TOOLSET_ARGS% --target=%NODE_RUNTIME_VERSION%"
 
 ECHO APPVEYOR^: %APPVEYOR%
 ECHO nodejs_version^: %nodejs_version%

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -162,10 +162,6 @@ CALL npm install -g "electron@%NODE_RUNTIME_VERSION%"
 ECHO installing electron-mocha
 CALL npm install -g electron-mocha
 ECHO preparing tests
-(
-    ECHO var {app} = require('electron'^);
-    ECHO require('./createdb.js'^)(function (^) { app.quit(^); }^);
-) >"test\support\createdb-electron.js"
 CALL electron "test/support/createdb-electron.js"
 DEL "test\support\createdb-electron.js"
 ECHO calling electron-mocha

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -161,6 +161,13 @@ ECHO installing electron
 CALL npm install -g "electron@%NODE_RUNTIME_VERSION%"
 ECHO installing electron-mocha
 CALL npm install -g electron-mocha
+ECHO preparing tests
+(
+    ECHO var {app} = require('electron'^);
+    ECHO require('./createdb.js'^)(function (^) { app.quit(^); }^);
+) >"test\support\createdb-electron.js"
+CALL electron "test/support/createdb-electron.js"
+DEL "test\support\createdb-electron.js"
 ECHO calling electron-mocha
 CALL electron-mocha -R spec --timeout 480000
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -126,7 +126,7 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 CALL npm install --build-from-source --msvs_version=%msvs_version% %TOOLSET_ARGS% --loglevel=http
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-FOR /F "tokens=*" %%i in ('CALL node_modules\.bin\node-pre-gyp reveal module %TOOLSET_ARGS% --silent') DO SET MODULE=%%i
+FOR /F "tokens=*" %%i in ('"CALL node_modules\.bin\node-pre-gyp reveal module %TOOLSET_ARGS% --silent"') DO SET MODULE=%%i
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 FOR /F "tokens=*" %%i in ('node -e "console.log(process.execPath)"') DO SET NODE_EXE=%%i
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR

--- a/scripts/build_against_electron.sh
+++ b/scripts/build_against_electron.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+source ~/.nvm/nvm.sh
+
+set -e -u
+
+export DISPLAY=":99.0"
+GYP_ARGS="--runtime=electron --target=${ELECTRON_VERSION} --dist-url=https://atom.io/download/electron"
+NPM_BIN_DIR="$(npm bin -g 2>/dev/null)"
+
+function publish() {
+    if [[ ${PUBLISHABLE:-false} == true ]] && [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then
+        node-pre-gyp package
+        node-pre-gyp publish
+        node-pre-gyp info
+    fi
+}
+
+function electron_pretest() {
+    npm install -g electron
+    npm install -g electron-mocha
+    sh -e /etc/init.d/xvfb start
+    sleep 3
+}
+
+function electron_test() {
+    "$NPM_BIN_DIR"/electron test/support/createdb-electron.js
+    "$NPM_BIN_DIR"/electron-mocha -R spec --timeout 480000
+}
+
+# test installing from source
+npm install --build-from-source  --clang=1 $GYP_ARGS
+electron_pretest
+electron_test
+
+publish
+make clean
+
+# now test building against shared sqlite
+export NODE_SQLITE3_JSON1=no
+if [[ $(uname -s) == 'Darwin' ]]; then
+    brew install sqlite
+    npm install --build-from-source --sqlite=$(brew --prefix) --clang=1 $GYP_ARGS
+else
+    npm install --build-from-source --sqlite=/usr --clang=1 $GYP_ARGS
+fi
+electron_test
+export NODE_SQLITE3_JSON1=yes
+

--- a/scripts/build_against_electron.sh
+++ b/scripts/build_against_electron.sh
@@ -17,7 +17,7 @@ function publish() {
 }
 
 function electron_pretest() {
-    npm install -g electron
+    npm install -g electron@${ELECTRON_VERSION}
     npm install -g electron-mocha
     sh -e /etc/init.d/xvfb start
     sleep 3

--- a/test/support/createdb-electron.js
+++ b/test/support/createdb-electron.js
@@ -1,0 +1,7 @@
+
+var {app} = require('electron');
+var createdb = require('./createdb.js');
+
+createdb(function () {
+    app.quit();
+});

--- a/test/support/createdb.js
+++ b/test/support/createdb.js
@@ -1,36 +1,47 @@
 #!/usr/bin/env node
 
-var existsSync = require('fs').existsSync || require('path').existsSync;
-var path = require('path');
+function createdb(callback) {
+    var existsSync = require('fs').existsSync || require('path').existsSync;
+    var path = require('path');
 
-var sqlite3 = require('../../lib/sqlite3');
+    var sqlite3 = require('../../lib/sqlite3');
 
-var count = 1000000;
-var db_path = path.join(__dirname,'big.db');
+    var count = 1000000;
+    var db_path = path.join(__dirname,'big.db');
 
-function randomString() {
-    var str = '';
-    var chars = 'abcdefghijklmnopqrstuvwxzyABCDEFGHIJKLMNOPQRSTUVWXZY0123456789  ';
-    for (var i = Math.random() * 100; i > 0; i--) {
-        str += chars[Math.floor(Math.random() * chars.length)];
+    function randomString() {
+        var str = '';
+        var chars = 'abcdefghijklmnopqrstuvwxzyABCDEFGHIJKLMNOPQRSTUVWXZY0123456789  ';
+        for (var i = Math.random() * 100; i > 0; i--) {
+            str += chars[Math.floor(Math.random() * chars.length)];
+        }
+        return str;
+    };
+
+
+    if (existsSync(db_path)) {
+        console.log('okay: database already created (' + db_path + ')');
+        if (callback) callback();
+    } else {
+        console.log("Creating test database... This may take several minutes.");
+        var db = new sqlite3.Database(db_path);
+        db.serialize(function() {
+            db.run("CREATE TABLE foo (id INT, txt TEXT)");
+            db.run("BEGIN TRANSACTION");
+            var stmt = db.prepare("INSERT INTO foo VALUES(?, ?)");
+            for (var i = 0; i < count; i++) {
+                stmt.run(i, randomString());
+            }
+            stmt.finalize();
+            db.run("COMMIT TRANSACTION", [], function () {
+                db.close(callback);
+            });
+        });
     }
-    return str;
 };
 
-
-if (existsSync(db_path)) {
-    console.log('okay: database already created (' + db_path + ')');
-} else {
-    console.log("Creating test database... This may take several minutes.");
-    var db = new sqlite3.Database(db_path);
-    db.serialize(function() {
-        db.run("CREATE TABLE foo (id INT, txt TEXT)");
-        db.run("BEGIN TRANSACTION");
-        var stmt = db.prepare("INSERT INTO foo VALUES(?, ?)");
-        for (var i = 0; i < count; i++) {
-            stmt.run(i, randomString());
-        }
-        stmt.finalize();
-        db.run("COMMIT TRANSACTION");
-    });
+if (require.main === module) {
+    createdb();
 }
+
+module.exports = createdb;


### PR DESCRIPTION
Adds builds against Electron to CI configuration (both Travis and Appveyor).

The change to `test/support/createdb.js` is needed to quit electron only after the script ends,
as `app.quit()` kills the whole process immediately.

Please consider merging this PR and distributing resulting binaries same way as Node ones.