### PR TITLE
Update node-pre-gyp dependency to 0.6.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "nan": "~2.4.0",
-    "node-pre-gyp": "~0.6.32"
+    "node-pre-gyp": "~0.6.36"
   },
   "bundledDependencies": [		
       "node-pre-gyp"		


### PR DESCRIPTION
We are failing to run our sqlite tests in Jest due to the `node-pre-gyp` issue that was fixed by this PR: https://github.com/mapbox/node-pre-gyp/pull/259; bumping the dependency fixes it.