### PR TITLE
bumped node-pre-gyp version to solve package issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "nan": "~2.4.0",
-    "node-pre-gyp": "~0.6.32"
+    "node-pre-gyp": "~0.6.33"
   },
   "bundledDependencies": [		
       "node-pre-gyp"		


### PR DESCRIPTION
Node-pre-gyp versions 0.6.33 and higher fix this issue that causes all of our backend jest test suites to fail silently: https://github.com/mapbox/node-pre-gyp/issues/262