### PR TITLE
Fix logic to allow binaries to run on old centos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,9 +132,10 @@ before_script:
    fi
 
 script:
+- export CXXFLAGS="${CXXFLAGS:-} -include $(pwd)/src/gcc-preinclude.h"
 - if [[ "${NODE_VERSION}" ]]; then ./scripts/build_against_node.sh; fi;
-- nm lib/binding/*/node_sqlite3.node | grep "GLIBCXX_" || true
-- nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" || true
+- nm lib/binding/*/node_sqlite3.node | grep "GLIBCXX_" | c++filt  || true
+- nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" | c++filt || true
 - if [[ "${NODE_VERSION}" -eq "4" ]]; then ./node_modules/.bin/eslint lib; fi;
 # disabled for now: need to port to sudo:false
 #- if [[ "${NODE_WEBKIT}" ]]; then ./scripts/build_against_node_webkit.sh; fi;

--- a/binding.gyp
+++ b/binding.gyp
@@ -31,7 +31,6 @@
         }
         ]
       ],
-      "cflags": [ "-include ../src/gcc-preinclude.h" ],
       "sources": [
         "src/database.cc",
         "src/node_sqlite3.cc",

--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -71,7 +71,6 @@
       'dependencies': [
         'action_before_build'
       ],
-      'cflags': [ '-include ../src/gcc-preinclude.h' ],
       'sources': [
         '<(SHARED_INTERMEDIATE_DIR)/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
       ],
@@ -87,8 +86,7 @@
         ],
       },
       'cflags_cc': [
-          '-Wno-unused-value',
-          '-include ../src/gcc-preinclude.h'
+          '-Wno-unused-value'
       ],
       'defines': [
         '_REENTRANT=1',


### PR DESCRIPTION
We've long had a trick in the build system to apply:

```c
__asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
```

to the code dynamically when compiling the binaries on linux.

Without this trick the binaries will end up having a runtime link to `memcpy@@GLIBC_2.14` within `libc` due to [how symbol versioning works for libc](https://github.com/springmeyer/glibcxx-symbol-versioning).

With this trick the binaries will only depend on `memcpy@GLIBC_2.2.5`, which allows them to work without upgrading libc on older linux systems.

The problem with this approach was that it could break on different linux versions that don't use glic. So this PR moves the logic such that it is only applied on travis builds for binaries. This means that source compiles will not use the hack and anyone needing to build for alpine linux (which uses musl instead of libc) should not hit a problem.

I've confirmed this branch keeps the `memcpy@GLIBC_2.2.5` fix in place:

```
0.01s$ nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" | c++filt || true
                 w __cxa_finalize@@GLIBC_2.2.5
                 w __pthread_key_create@@GLIBC_2.2.5
                 U free@@GLIBC_2.2.5
                 U malloc@@GLIBC_2.2.5
                 U memcpy@GLIBC_2.2.5
                 U memmove@@GLIBC_2.2.5
                 U pthread_mutex_destroy@@GLIBC_2.2.5
                 U pthread_mutex_init@@GLIBC_2.2.5
                 U pthread_mutex_lock@@GLIBC_2.2.5
                 U pthread_mutex_unlock@@GLIBC_2.2.5
```

Without it the binaries would look like:

```
0.01s$ nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" || true
                 w __cxa_finalize@@GLIBC_2.2.5
                 w __pthread_key_create@@GLIBC_2.2.5
                 U free@@GLIBC_2.2.5
                 U malloc@@GLIBC_2.2.5
                 U memcpy@@GLIBC_2.14
                 U memmove@@GLIBC_2.2.5
                 U pthread_mutex_destroy@@GLIBC_2.2.5
                 U pthread_mutex_init@@GLIBC_2.2.5
                 U pthread_mutex_lock@@GLIBC_2.2.5
                 U pthread_mutex_unlock@@GLIBC_2.2.5
```