### PR TITLE
added backup function to database object

### DIFF
--- a/scripts/build_against_node.sh
+++ b/scripts/build_against_node.sh
@@ -29,6 +29,7 @@ publish
 # now test building against shared sqlite
 export NODE_SQLITE3_JSON1=no
 if [[ $(uname -s) == 'Darwin' ]]; then
+    brew update
     brew install sqlite
     npm install --build-from-source --sqlite=$(brew --prefix) --clang=1
 else

--- a/src/database.cc
+++ b/src/database.cc
@@ -430,7 +430,7 @@ void Database::Work_AfterBackup(uv_work_t* req) {
     Local<Function> cb = Nan::New(baton->callback);
 
     if (baton->status != SQLITE_OK) {
-        EXCEPTION(Nan::New(baton->message.c_str()).ToLocalChecked(), baton->status, exception);
+        EXCEPTION(baton->message, baton->status, exception);
 
         if (!cb.IsEmpty() && cb->IsFunction()) {
             Local<Value> argv[] = { exception };

--- a/src/database.h
+++ b/src/database.h
@@ -68,6 +68,12 @@ public:
             Baton(db_, cb_), filename(filename_) {}
     };
 
+    struct BackupBaton : Baton {
+        std::string filename;
+        BackupBaton(Database* db_, Local<Function> cb_, const char* filename_) :
+            Baton(db_, cb_), filename(filename_) {}
+    };
+
     typedef void (*Work_Callback)(Baton* baton);
 
     struct Call {
@@ -153,6 +159,11 @@ protected:
     static NAN_METHOD(Configure);
 
     static NAN_METHOD(Interrupt);
+
+    static NAN_METHOD(Backup);
+    static void Work_BeginBackup(Baton* baton);
+    static void Work_Backup(uv_work_t* req);
+    static void Work_AfterBackup(uv_work_t* req);
 
     static void SetBusyTimeout(Baton* baton);
 

--- a/src/macros.h
+++ b/src/macros.h
@@ -4,6 +4,7 @@
 const char* sqlite_code_string(int code);
 const char* sqlite_authorizer_string(int type);
 
+#define UNUSED_VARIABLE(var) (void)var
 
 #define REQUIRE_ARGUMENTS(n)                                                   \
     if (info.Length() < (n)) {                                                 \

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -1,0 +1,14 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+
+describe('backup', function() {
+    var db;
+    before(function(done) {
+        db = new sqlite3.Database('test/support/prepare.db', sqlite3.OPEN_READONLY, done);
+    });
+
+    it('backup database', function(done) {
+        db.backup('test/support/backup.db', done);
+    });
+});
+


### PR DESCRIPTION
I wanted to have the backup support from sqlite3 exposed in node-sqlite3 for a project I am working on. Here is a link to the documentation for this API: [Using the SQLite Online Backup API](https://sqlite.org/backup.html). I have included a unit test that just makes a backup of an existing database in the test/support directory. I only tested this on my ArchLinux server.