### PR TITLE
Visual studio build fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,46 +6,36 @@ environment:
   matrix:
     - nodejs_version: 0.10
       platform: x86
-      msvs_toolset: 12
     - nodejs_version: 0.10
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 0.12
       platform: x86
-      msvs_toolset: 12
     - nodejs_version: 0.12
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 4
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 4
       platform: x86
-      msvs_toolset: 12
     - nodejs_version: 5
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 5
       platform: x86
-      msvs_toolset: 12
     - nodejs_version: 6
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 6
       platform: x86
-      msvs_toolset: 12
     - nodejs_version: 7
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 7
       platform: x86
-      msvs_toolset: 12
     - nodejs_version: 8
       platform: x64
-      msvs_toolset: 12
     - nodejs_version: 8
       platform: x86
-      msvs_toolset: 12
+    - nodejs_version: 9
+      platform: x64
+    - nodejs_version: 9
+      platform: x86
     # custom visual studio 2015 builds
     - nodejs_version: 0.10.40
       platform: x86

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "git://github.com/mapbox/node-sqlite3.git"
   },
   "dependencies": {
-    "nan": "~2.7.0",
+    "nan": "~2.8.0",
     "node-pre-gyp": "~0.6.38"
   },
   "bundledDependencies": [

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -4,8 +4,8 @@ SET EL=0
 
 ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-IF "%msvs_toolset%"=="" ECHO "msvs_toolset unset, defaulting to 12" && SET msvs_toolset=12
-IF %NODE_MAJOR% GTR 4 ECHO "detected >= node v5, forcing msvs_toolset=14" && SET msvs_toolset=14
+IF /I "%msvs_toolset%"=="" ECHO msvs_toolset unset, defaulting to 12 && SET msvs_toolset=12
+IF %NODE_MAJOR% GTR 4 ECHO detected node v5, forcing msvs_toolset 14 && SET msvs_toolset=14
 
 SET PATH=%CD%;%PATH%
 SET msvs_version=2013

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -115,11 +115,11 @@ IF /I "%NPM_BIN_DIR%"=="%CD%" ECHO ERROR npm bin -g equals local directory && SE
 ECHO ===== where npm puts stuff END ============
 
 
-IF "%nodejs_version:~0,1%"=="0" npm install https://github.com/springmeyer/node-gyp/tarball/v3.x
+IF "%nodejs_version:~0,1%"=="0" CALL npm install https://github.com/springmeyer/node-gyp/tarball/v3.x
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF "%nodejs_version:~0,1%"=="4" npm install node-gyp@3.x
+IF "%nodejs_version:~0,1%"=="4" CALL npm install node-gyp@3.x
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
-IF "%nodejs_version:~0,1%"=="5" npm install node-gyp@3.x
+IF "%nodejs_version:~0,1%"=="5" CALL npm install node-gyp@3.x
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 CALL npm install --build-from-source --msvs_version=%msvs_version% %TOOLSET_ARGS% --loglevel=http

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -119,6 +119,8 @@ IF "%nodejs_version:~0,1%"=="0" npm install https://github.com/springmeyer/node-
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 IF "%nodejs_version:~0,1%"=="4" npm install node-gyp@3.x
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
+IF "%nodejs_version:~0,1%"=="5" npm install node-gyp@3.x
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 CALL npm install --build-from-source --msvs_version=%msvs_version% %TOOLSET_ARGS% --loglevel=http
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -4,9 +4,13 @@ SET EL=0
 
 ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+IF "%msvs_toolset%"=="" ECHO "msvs_toolset unset, defaulting to 12" && SET msvs_toolset=12
+IF %NODE_MAJOR% GTR 4 ECHO "detected >= node v5, forcing msvs_toolset=14" && SET msvs_toolset=14
+
 SET PATH=%CD%;%PATH%
 SET msvs_version=2013
 IF "%msvs_toolset%"=="14" SET msvs_version=2015
+
 
 ECHO APPVEYOR^: %APPVEYOR%
 ECHO nodejs_version^: %nodejs_version%
@@ -51,6 +55,7 @@ IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 :SKIP_APPVEYOR_INSTALL
 IF /I "%msvs_toolset%"=="12" GOTO NODE_INSTALLED
+IF %NODE_MAJOR% GTR 4 GOTO NODE_INSTALLED
 
 
 ::custom node for VS2015

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -5,6 +5,7 @@ SET EL=0
 ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ %~f0 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 IF /I "%msvs_toolset%"=="" ECHO msvs_toolset unset, defaulting to 12 && SET msvs_toolset=12
+SET NODE_MAJOR=%nodejs_version:~0,1%
 IF %NODE_MAJOR% GTR 4 ECHO detected node v5, forcing msvs_toolset 14 && SET msvs_toolset=14
 
 SET PATH=%CD%;%PATH%
@@ -46,7 +47,6 @@ IF /I "%platform%"=="x64" powershell Install-Product node $env:nodejs_version x6
 IF /I "%platform%"=="x86" powershell Install-Product node $env:nodejs_version x86
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
-SET NODE_MAJOR=%nodejs_version:~0,1%
 ECHO node major version^: %NODE_MAJOR%
 IF %NODE_MAJOR% GTR 0 ECHO node version greater than zero, not updating npm && GOTO SKIP_APPVEYOR_INSTALL
 


### PR DESCRIPTION
Starts:

 - Building with `msvs_toolset=14` when using > node v4
 - Fixes node v9 build which requires `msvs_toolset=14` and `Visual Studio >= 2015` to support `constexpr` - refs #920