### PR TITLE
Upgrade Travis to use the Trusty environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ dist: trusty
 git:
   depth: 10
 
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-trusty-3.9
-    packages:
-     - clang-3.9
-
 matrix:
   include:
      # Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,42 +23,36 @@ matrix:
        env: NODE_VERSION="9"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="8"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="7"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="6"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="5"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="4"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      # test building against external sqlite
      - os: linux
@@ -66,7 +60,6 @@ matrix:
        env: NODE_VERSION="8" EXTERNAL_SQLITE=true PUBLISHABLE=false
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9','libsqlite3-dev']
      # OS X
      - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: generic
 
-dist: precise
+dist: trusty
 
 git:
   depth: 10
@@ -11,9 +11,9 @@ addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.5
+    - llvm-toolchain-trusty-3.9
     packages:
-     - clang-3.5
+     - clang-3.9
 
 matrix:
   include:
@@ -23,51 +23,51 @@ matrix:
        env: NODE_VERSION="9"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="8"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="7"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="6"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="5"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="4"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9']
      # test building against external sqlite
      - os: linux
        compiler: clang
        env: NODE_VERSION="8" EXTERNAL_SQLITE=true PUBLISHABLE=false
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5','libsqlite3-dev']
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.9','libsqlite3-dev']
      # OS X
      - os: osx
        compiler: clang
@@ -99,8 +99,8 @@ before_install:
 - export PUBLISHABLE=${PUBLISHABLE:-true}
 - export COVERAGE=${COVERAGE:-false}
 - if [[ $(uname -s) == 'Linux' ]]; then
-    export CXX="clang++-3.5";
-    export CC="clang-3.5";
+    export CXX="clang++-3.9";
+    export CC="clang-3.9";
     export PYTHONPATH=$(pwd)/py-local/lib/python2.7/site-packages;
   else
     export PYTHONPATH=$(pwd)/py-local/lib/python/site-packages;

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ matrix:
      # OS X
      - os: osx
        compiler: clang
+       osx_image: xcode9.4
        env: NODE_VERSION="5" COVERAGE=true PUBLISHABLE=false # node abi 47
      - os: osx
        compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,42 +23,42 @@ matrix:
        env: NODE_VERSION="9"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="8"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="7"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="6"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="5"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      - os: linux
        compiler: clang
        env: NODE_VERSION="4"
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9']
      # test building against external sqlite
      - os: linux
@@ -66,7 +66,7 @@ matrix:
        env: NODE_VERSION="8" EXTERNAL_SQLITE=true PUBLISHABLE=false
        addons:
          apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-trusty-3.9' ]
             packages: [ 'clang-3.9','libsqlite3-dev']
      # OS X
      - os: osx

--- a/scripts/build_against_node.sh
+++ b/scripts/build_against_node.sh
@@ -17,7 +17,7 @@ function publish() {
 if [[ ${COVERAGE} == true ]]; then
     CXXFLAGS="--coverage" LDFLAGS="--coverage" npm install --build-from-source  --clang=1
     npm test
-    ./py-local/bin/cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude docs --exclude build/Release/obj/gen --exclude deps  > /dev/null
+    ./py-local/bin/cpp-coveralls --exclude node_modules --exclude tests --build-root build --gcov-options '\-lp' --exclude docs --exclude build/Release/obj/gen --exclude deps
 else
     echo "building binaries for publishing"
     CFLAGS="${CFLAGS:-} -include $(pwd)/src/gcc-preinclude.h" CXXFLAGS="${CXXFLAGS:-} -include $(pwd)/src/gcc-preinclude.h" V=1 npm install --build-from-source  --clang=1


### PR DESCRIPTION
Travis' Precise environment is now deprecated, and so we need to upgrade to the newer option.