### PR TITLE
Add support for running inside a node 10.5 worker_thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "prepublishOnly": "npm ls",
     "install": "node-pre-gyp install --fallback-to-build",
     "pretest": "node test/support/createdb.js",
-    "test": "mocha -R spec --timeout 480000"
+    "test": "mocha -R spec --timeout 480000",
+    "test:worker": "node --experimental-worker scripts/mocha-as-worker.js -R spec --timeout 480000"
   },
   "license": "BSD-3-Clause",
   "keywords": [

--- a/scripts/mocha-as-worker.js
+++ b/scripts/mocha-as-worker.js
@@ -1,0 +1,13 @@
+// Run the mocha tests in a worker
+// Not a clean approach, but is sufficient to verify correctness
+const worker_threads = require("worker_threads");
+const path = require("path");
+
+if (worker_threads.isMainThread) {
+	const worker = new worker_threads.Worker(__filename, { workerData: { windowSize: process.stdout.getWindowSize() } });
+	worker.on("error", console.error);
+} else {
+	process.stdout.getWindowSize = () => worker_threads.workerData.windowSize;
+	const mochaPath = path.resolve(require.resolve("mocha"), "../bin/_mocha");
+	require(mochaPath);
+}

--- a/src/async.h
+++ b/src/async.h
@@ -22,11 +22,11 @@ public:
     Parent* parent;
 
 public:
-    Async(Parent* parent_, Callback cb_)
+    Async(uv_loop_t* loop_, Parent* parent_, Callback cb_)
         : callback(cb_), parent(parent_) {
         watcher.data = this;
         NODE_SQLITE3_MUTEX_INIT
-        uv_async_init(uv_default_loop(), &watcher, reinterpret_cast<uv_async_cb>(listener));
+        uv_async_init(loop_, &watcher, reinterpret_cast<uv_async_cb>(listener));
     }
 
     static void listener(uv_async_t* handle, int status) {

--- a/src/database.cc
+++ b/src/database.cc
@@ -127,7 +127,12 @@ NAN_METHOD(Database::New) {
         callback = Local<Function>::Cast(info[pos++]);
     }
 
-    Database* db = new Database(node::GetCurrentEventLoop(info.GetIsolate()));
+#if NODE_MODULE_VERSION > NODE_9_0_MODULE_VERSION
+    uv_loop_t* loop = node::GetCurrentEventLoop(info.GetIsolate());
+#else
+    uv_loop_t* loop = uv_default_loop();
+#endif
+    Database* db = new Database(loop);
     db->Wrap(info.This());
 
     Nan::ForceSet(info.This(), Nan::New("filename").ToLocalChecked(), info[0].As<String>(), ReadOnly);

--- a/src/database.h
+++ b/src/database.h
@@ -100,8 +100,9 @@ public:
     friend class Statement;
 
 protected:
-    Database() : Nan::ObjectWrap(),
+    Database(uv_loop_t* loop_) : Nan::ObjectWrap(),
         _handle(NULL),
+        loop(loop_),
         open(false),
         closing(false),
         locked(false),
@@ -172,7 +173,10 @@ protected:
 
 protected:
     sqlite3* _handle;
+public:
+    uv_loop_t* loop;
 
+protected:
     bool open;
     bool closing;
     bool locked;

--- a/src/macros.h
+++ b/src/macros.h
@@ -122,7 +122,7 @@ const char* sqlite_authorizer_string(int type);
     assert(baton->stmt->prepared);                                             \
     baton->stmt->locked = true;                                                \
     baton->stmt->db->pending++;                                                \
-    int status = uv_queue_work(uv_default_loop(),                              \
+    int status = uv_queue_work(baton->stmt->db->loop,                          \
         &baton->request,                                                       \
         Work_##type, reinterpret_cast<uv_after_work_cb>(Work_After##type));    \
     assert(status == 0);

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -115,7 +115,7 @@ NAN_METHOD(Statement::New) {
 void Statement::Work_BeginPrepare(Database::Baton* baton) {
     assert(baton->db->open);
     baton->db->pending++;
-    int status = uv_queue_work(uv_default_loop(),
+    int status = uv_queue_work(baton->db->loop,
         &baton->request, Work_Prepare, (uv_after_work_cb)Work_AfterPrepare);
     assert(status == 0);
 }

--- a/src/statement.h
+++ b/src/statement.h
@@ -174,7 +174,7 @@ public:
             watcher.data = this;
             NODE_SQLITE3_MUTEX_INIT
             stmt->Ref();
-            uv_async_init(uv_default_loop(), &watcher, async_cb);
+            uv_async_init(stmt->db->loop, &watcher, async_cb);
         }
 
         ~Async() {


### PR DESCRIPTION
Properly tracks which event loop callbacks should be dispatched on so that node doesn't busy loop on the main thread if node-sqlite3 is called from a worker.