### PR TITLE
Fix compile issue introduced by nodejs change (increment node-pre-gyp version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "nan": "~2.10.0",
-    "node-pre-gyp": "^0.10.3",
+    "node-pre-gyp": "^0.11.0",
     "request": "^2.87.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating node-pre-gyp to 0.11 fixes a compile error caused by nodejs/node#21063 and mapbox/node-pre-gyp#391. The issue irregularly occurs due to upstream changes to callbacks which, following a download failure, can cause duplicate callbacks which result in two builds of sqlite3 instead of one; the build consequently fails because the second build often removes files created by the first build. See: mapbox/node-pre-gyp#408