### PR TITLE
Update SQLCipher section of README with static linking instructions for Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,18 @@ Remember the following:
 
 Visit the “[Using Node modules](https://github.com/rogerwang/node-webkit/wiki/Using-Node-modules)” article in the node-webkit's wiki for more details.
 
-## Building for sqlcipher
+## Building for SQLCipher
 
-For instructions for building sqlcipher see
+For instructions for building SQLCipher see
 [Building SQLCipher for node.js](https://coolaj86.com/articles/building-sqlcipher-for-node-js-on-raspberry-pi-2/)
 
-To run node-sqlite3 against sqlcipher you need to compile from source by passing build options like:
+To run node-sqlite3 against SQLCipher you need to compile from source by passing build options like:
 
     npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=/usr/
 
     node -e 'require("sqlite3")'
 
-If your sqlcipher is installed in a custom location (if you compiled and installed it yourself),
+If your SQLCipher is installed in a custom location (if you compiled and installed it yourself),
 you'll also need to to set some environment variables:
 
 ### On OS X with Homebrew
@@ -159,7 +159,7 @@ Set the location where `make` installed it:
 
 ### Custom builds and Electron
 
-Running sqlite3 through [electron-rebuild](https://github.com/electron/electron-rebuild) does not preserve the sqlcipher extension, so some additional flags are needed to make this build Electron compatible. Your `npm install sqlite3 --build-from-source` command needs these additional flags (be sure to replace the target version with the current Electron version you are working with):
+Running sqlite3 through [electron-rebuild](https://github.com/electron/electron-rebuild) does not preserve the SQLCipher extension, so some additional flags are needed to make this build Electron compatible. Your `npm install sqlite3 --build-from-source` command needs these additional flags (be sure to replace the target version with the current Electron version you are working with):
 
     --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
 

--- a/README.md
+++ b/README.md
@@ -173,15 +173,15 @@ By default, SQLite bindings are compiled with *dynamic linking* to SQLite. If yo
 Electron app with SQLCipher, it's unlikely that your users will have SQLCipher on their machine,
 causing your Electron app to crash during deployment to machines without SQLCipher. You can force
 *static linking* of SQLCipher by adjusting LDFLAGS to point to the sqlcipher.a file. This will
-ensure SQLCipher is distribute with your app. For example, to statically link a Homebrew-installed
+ensure SQLCipher is distributed with your app. For example, to statically link a Homebrew-installed
 SQLCipher on macOS for Electron:
 
     export LDFLAGS="-L`brew --prefix`/opt/sqlcipher/lib/libsqlcipher.a"
     export CPPFLAGS="-I`brew --prefix`/opt/sqlcipher/include"
-    npm rebuild sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron &>/dev/null
+    npm rebuild sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
 
-Notice the resulting value of LDFLAGS value with this command will end up beging
-`-L/usr/local/opt/sqlcipher/lib/libsqlcipher.a` (the actual static library file) instead of
+Notice the resulting value of LDFLAGS value with this command will end up being
+`-L/usr/local/opt/sqlcipher/lib/libsqlcipher.a` (the static library file) instead of
 `-L/usr/local/opt/sqlcipher/lib` (the directory, which will result in dynamic linking).
 
 # Testing

--- a/README.md
+++ b/README.md
@@ -167,6 +167,23 @@ In the case of MacOS with Homebrew, the command should look like the following:
 
     npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
 
+#### Static linking SQLCipher
+
+By default, SQLite bindings are compiled with *dynamic linking* to SQLite. If you're distributing an
+Electron app with SQLCipher, it's unlikely that your users will have SQLCipher on their machine,
+causing your Electron app to crash during deployment to machines without SQLCipher. You can force
+*static linking* of SQLCipher by adjusting LDFLAGS to point to the sqlcipher.a file. This will
+ensure SQLCipher is distribute with your app. For example, to statically link a Homebrew-installed
+SQLCipher on macOS for Electron:
+
+    export LDFLAGS="-L`brew --prefix`/opt/sqlcipher/lib/libsqlcipher.a"
+    export CPPFLAGS="-I`brew --prefix`/opt/sqlcipher/include"
+    npm rebuild sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron &>/dev/null
+
+Notice the resulting value of LDFLAGS value with this command will end up beging
+`-L/usr/local/opt/sqlcipher/lib/libsqlcipher.a` (the actual static library file) instead of
+`-L/usr/local/opt/sqlcipher/lib` (the directory, which will result in dynamic linking).
+
 # Testing
 
 [mocha](https://github.com/visionmedia/mocha) is required to run unit tests.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ In the case of MacOS with Homebrew, the command should look like the following:
 
     npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
 
-#### Static linking SQLCipher
+#### Static linking SQLCipher for Electron
 
 By default, SQLite bindings are compiled with *dynamic linking* to SQLite. If you're distributing an
 Electron app with SQLCipher, it's unlikely that your users will have SQLCipher on their machine,


### PR DESCRIPTION
Related to:
* https://github.com/mapbox/node-sqlite3/issues/1065
* https://github.com/mapbox/node-sqlite3/pull/1066

Simple instructions to modify LDFLAGS seems more graceful than hacking up binding.gyp to support a non-core use case via a flag.