### PR TITLE
Docs: Static linking of SQLCipher for Electron app distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ In the case of MacOS with Homebrew, the command should look like the following:
 
     npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
 
+#### Static linking of SQLCipher for Electron app distribution
+
+The commands above will produce a SQLite binding that is *dynamically linked* to SQLCipher, meaning
+that your Electron app will require SQLCipher development headers to be present on the machine your
+app is running on. If you're broadly distributing an Electron app, it's unlikely that your users
+will have SQLCipher development headers installed on their machine. You should distribute a SQLite
+binding that is *statically linked* the SQLCipher library so that SQLCipher is distributed with your
+app. This requires modifying ./node_modules/sqlite3/binding.gyp and rebuilding. For more information
+on doing this, see
+[this gist](https://gist.github.com/aguynamedben/c69e4ece4c3c7f057bcaac7ad7fc30bc). It's especially
+tricky to test because as a developer you *will* have SQLCipher installed. To ensure everything is
+working for your end users, uninstall SQLCipher (i.e. `brew uninstall sqlcipher`) and ensure your
+app still works. Only then will any hidden dynamic linking problem become apparent.
+
 # Testing
 
 [mocha](https://github.com/visionmedia/mocha) is required to run unit tests.

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ In the case of MacOS with Homebrew, the command should look like the following:
 The commands above will produce a SQLite binding that is *dynamically linked* to SQLCipher, meaning
 that your Electron app will require SQLCipher development headers to be present on the machine your
 app is running on. If you're broadly distributing an Electron app, it's unlikely that your users
-will have SQLCipher development headers installed on their machine. You should distribute a SQLite
-binding that is *statically linked* the SQLCipher library so that SQLCipher is distributed with your
-app. This requires modifying ./node_modules/sqlite3/binding.gyp and rebuilding. For more information
-on doing this, see
+will have SQLCipher development headers installed on their machine, and as a result your app will
+crash. You should distribute a SQLite binding that is *statically linked* the SQLCipher library so
+that SQLCipher is distributed with your app. This requires modifying
+./node_modules/sqlite3/binding.gyp and rebuilding. For more information on doing this, see
 [this gist](https://gist.github.com/aguynamedben/c69e4ece4c3c7f057bcaac7ad7fc30bc). It's especially
 tricky to test because as a developer you *will* have SQLCipher installed. To ensure everything is
 working for your end users, uninstall SQLCipher (i.e. `brew uninstall sqlcipher`) and ensure your


### PR DESCRIPTION
The README leads users to build node-sqlite3 with dynamic linking to SQLCipher.
During Electron app distribution, end users will not have SQLCipher development
headers installed, causing Electron apps to crash.

This adds a section in the README explaining how to rebuild
node-sqlite3 bindings with static linking to SQLCipher.

The docs link to this gist which should be reviewed as well: https://gist.github.com/aguynamedben/c69e4ece4c3c7f057bcaac7ad7fc30bc

I've been testing this for a few days, and it's very tricky to get right, but I'm pretty confident I have it correct now. Hopefully this helps save others 1.5-2 days of confusing tweaks, compiling, installing/uninstalling of SQLCipher, etc.