### PR TITLE
[WIP][stalled] ARM Build in Docker in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: generic
 
-dist: precise
+# dist: precise
 
 git:
   depth: 10
@@ -15,8 +15,14 @@ addons:
   #   packages:
   #    - clang-3.5
 
+services:
+  - docker
+
 matrix:
   include:
+    # ARM with Docker
+     - os: linux
+       env: NODE_VERSION="8" USE_DOCKER=1
     #  # Linux
     #  - os: linux
     #    compiler: clang
@@ -208,6 +214,9 @@ before_script:
 - export COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
 
 script:
+- docker run --rm --privileged multiarch/qemu-user-static:register --reset
+- "mkdir tmp && pushd tmp && curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-3/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz && popd"
+- travis_wait docker run --rm -v "$(pwd)":/build -v "$(pwd)"/tmp/qemu-arm-static:/usr/bin/qemu-arm-static arm32v7/node:8 bash -c 'cd /build && npm install --unsafe-perm --build-from-source && node_modules/.bin/node-pre-gyp package testpackage publish info'
 # - if [[ "${NODE_VERSION}" ]]; then
 #     if [[ "${ELECTRON_VERSION}" ]]; then
 #       ./scripts/build_against_electron.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,180 +8,180 @@ git:
   depth: 10
 
 addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - llvm-toolchain-precise-3.5
-    packages:
-     - clang-3.5
+  # apt:
+  #   sources:
+  #   - ubuntu-toolchain-r-test
+  #   - llvm-toolchain-precise-3.5
+  #   packages:
+  #    - clang-3.5
 
 matrix:
   include:
-     # Linux
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="11"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="10"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="9"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="8"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="7"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="5"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="4"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     # test building against external sqlite
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="8" EXTERNAL_SQLITE=true PUBLISHABLE=false
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5','libsqlite3-dev']
-     # OS X
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="11" # node abi 67
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="10" # node abi 64
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="9" # node abi 59
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="8" # node abi 57
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="7" # node abi 51
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" # node abi 48
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="5" # node abi 47
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="4" # node abi 46
-     # electron Linux
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="4.0.0"
-       dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="3.0.6"
-       dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="2.0.1"
-       dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5', 'libc6']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.8.4"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.7.12"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.6.2"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.3.14"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     # electron MacOs
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="4.0.0"
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="3.0.6"
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="2.0.1"
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.8.4"
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.7.12"
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.6.2"
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="1.3.14"
+    #  # Linux
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="11"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="10"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="9"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="8"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="7"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="5"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="4"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  # test building against external sqlite
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="8" EXTERNAL_SQLITE=true PUBLISHABLE=false
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5','libsqlite3-dev']
+    #  # OS X
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="11" # node abi 67
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="10" # node abi 64
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="9" # node abi 59
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="8" # node abi 57
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="7" # node abi 51
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" # node abi 48
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="5" # node abi 47
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="4" # node abi 46
+    #  # electron Linux
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="4.0.0"
+    #    dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="3.0.6"
+    #    dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="2.0.1"
+    #    dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5', 'libc6']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.8.4"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.7.12"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.6.2"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  - os: linux
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.3.14"
+    #    addons:
+    #      apt:
+    #         sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+    #         packages: [ 'clang-3.5']
+    #  # electron MacOs
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="4.0.0"
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="3.0.6"
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="2.0.1"
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.8.4"
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.7.12"
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.6.2"
+    #  - os: osx
+    #    compiler: clang
+    #    env: NODE_VERSION="6" ELECTRON_VERSION="1.3.14"
 
 env:
   global:
@@ -208,13 +208,13 @@ before_script:
 - export COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
 
 script:
-- if [[ "${NODE_VERSION}" ]]; then
-    if [[ "${ELECTRON_VERSION}" ]]; then
-      ./scripts/build_against_electron.sh;
-    else
-      ./scripts/build_against_node.sh;
-    fi;
-  fi
-- if [[ "${NODE_VERSION}" -eq "4" ]]; then ./node_modules/.bin/eslint lib; fi;
+# - if [[ "${NODE_VERSION}" ]]; then
+#     if [[ "${ELECTRON_VERSION}" ]]; then
+#       ./scripts/build_against_electron.sh;
+#     else
+#       ./scripts/build_against_node.sh;
+#     fi;
+#   fi
+# - if [[ "${NODE_VERSION}" -eq "4" ]]; then ./node_modules/.bin/eslint lib; fi;
 # disabled for now: need to port to sudo:false
 #- if [[ "${NODE_WEBKIT}" ]]; then ./scripts/build_against_node_webkit.sh; fi;


### PR DESCRIPTION
This PR is at this stage a proof of concept of building ARM binary in Docker with Travis.

The first commit comments out the normal build.

The second commit has the real beef:
- use the default dist (Docker seems to be not available in `precise`)
- an additional dummy build target for ARM
- script steps to install ARM support and the docker command to build & publish inside the prebuilt arm32v7/node container off Docker hub

This works in Travis up to ["Package appears valid"](https://travis-ci.org/tkurki/node-sqlite3/builds/521698951#L2529) but naturally publish stage fails without the S3 credentials.

Is this something that you would consider merging? 

I have not tested the resulting binary yet.

If finalised and merged fixes #418.