### PR TITLE
tests: await for backup to complete before finish

### DIFF
--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -158,7 +158,7 @@ describe('backup', function() {
                 if (err) throw err;
                 var backup = db.backup('test/tmp/backup.db', 'temp', 'main', true, function(err) {
                     if (err) throw err;
-                    backup.step(-1);
+                    await backup.step(-1);
                     backup.finish(function(err) {
                         if (err) throw err;
                         var db2 = new sqlite3.Database('test/tmp/backup.db', function(err) {
@@ -178,7 +178,7 @@ describe('backup', function() {
     (sqlite3.VERSION_NUMBER < 3007011 ? it.skip : it) ('can backup from main to temp', function(done) {
         var backup = db.backup('test/support/prepare.db', 'main', 'temp', false, function(err) {
             if (err) throw err;
-            backup.step(-1);
+            await backup.step(-1);
             backup.finish(function(err) {
                 if (err) throw err;
                 assertRowsMatchDb(db, 'temp.foo', db, 'main.foo', done);


### PR DESCRIPTION
The CI is returning segfaults, I believe because the database objects are finished before the backup fully completes. I've added awaits.
@paulfitz 