### PR TITLE
ci: remove accidental distro upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   include:
      # Linux
      - os: linux
-       dist: xenial
+       dist: trusty
        compiler: clang
        env: NODE_VERSION="12"
        addons:


### PR DESCRIPTION
Alternative to #1165 as Trusty seems to be the lowest release supported by the official Node build.