### PR TITLE
tools: Crossbuild for ARMv7

### DIFF
--- a/tools/docker/architecture/linux-arm/Dockerfile
+++ b/tools/docker/architecture/linux-arm/Dockerfile
@@ -1,0 +1,81 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: ISC
+# Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+#{
+# ISC License
+# Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+# Copyright (c) 1995-2003 by Internet Software Consortium
+# Permission to use, copy, modify, and /or distribute this software
+# for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice
+#  and this permission notice appear in all copies.
+# THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS.
+# IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT,
+# OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE
+# OR PERFORMANCE OF THIS SOFTWARE.
+#}
+
+FROM resin/rpi-raspbian:stretch
+MAINTAINER Philippe Coval (p.coval@samsung.com)
+
+RUN [ "cross-build-start" ]
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL en_US.UTF-8
+ENV LANG ${LC_ALL}
+
+RUN echo "#log: Configuring locales" \
+  && set -x \
+  && apt-get update -y \
+  && apt-get install -y locales \
+  && echo "${LC_ALL} UTF-8" | tee /etc/locale.gen \
+  && locale-gen ${LC_ALL} \
+  && dpkg-reconfigure locales \
+  && sync
+
+ENV project node-sqlite3
+
+RUN echo "#log: ${project}: Setup system" \
+  && set -x \
+  && apt-get update -y \
+  && apt-get install -y \
+  curl \
+  sudo \
+  build-essential \
+  python \
+  && apt-get clean \
+  && NVM_VERSION="v0.33.8" \
+  && NODE_VERSION="--lts=carbon" \
+  && curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash \
+  && which nvm || . ~/.bashrc \
+  && nvm install ${NODE_VERSION} \
+  && nvm use ${NODE_VERSION} \
+  && sync
+
+ADD . /usr/local/opt/${project}/src/${project}
+WORKDIR /usr/local/opt/${project}/src/${project}
+RUN echo "#log: ${project}: Preparing sources" \
+  && set -x \
+  && which npm || . ~/.bashrc \
+  && npm install || cat npm-debug.log \
+  && npm install \
+  && npm install --unsafe-perm --build-from-source \
+  && sync
+
+WORKDIR /usr/local/opt/${project}/src/${project}
+RUN echo "#log: ${project}: Building sources" \
+  && set -x \
+  && which npm || . ~/.bashrc \
+  && npm run pack \
+  && npm pack \
+  && find ${PWD}/build/stage/ -type f \
+  && sync
+
+RUN [ "cross-build-end" ]

--- a/tools/docker/architecture/linux-arm/run.sh
+++ b/tools/docker/architecture/linux-arm/run.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: ISC
+# Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+#{
+# ISC License
+# Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+# Copyright (c) 1995-2003 by Internet Software Consortium
+# Permission to use, copy, modify, and /or distribute this software
+# for any purpose with or without fee is hereby granted,
+# provided that the above copyright notice
+#  and this permission notice appear in all copies.
+# THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS.
+# IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT,
+# OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT,
+# NEGLIGENCE OR OTHER TORTIOUS ACTION,
+# ARISING OUT OF OR IN CONNECTION WITH THE USE
+# OR PERFORMANCE OF THIS SOFTWARE.
+#}
+
+set -e
+set -x
+
+this_dir=$(dirname -- "$0")
+this_dir=$(realpath "${this_dir}")
+this_name=$(basename -- "$0")
+top_dir="${this_dir}/../../.."
+
+module_name="sqlite3"
+project="node-${module_name}"
+arch="arm"
+architecture=$(basename "${this_dir}")
+name="${project}-${architecture}"
+dir="/usr/local/opt/${project}/"
+dist_dir="${dir}/src/${project}/build"
+tag=$(git describe --tags || echo v0.0.0)
+version=$(echo "${tag}" | cut -dv -f2 | cut -d'-' -f1)
+
+mkdir -p "${this_dir}/local" "${this_dir}/tmp"
+cp -a "/usr/bin/qemu-${arch}-static" "${this_dir}/local"
+time docker build -t "${name}" -f "${this_dir}/Dockerfile" .
+container=$(docker create "${name}")
+mkdir -p "${this_dir}/tmp/${dist_dir}"
+rm -rf "${this_dir}/tmp/${dist_dir}"
+docker cp "${container}:${dist_dir}" "${this_dir}/tmp/${dist_dir}"
+file=$(ls "${this_dir}/tmp/${dist_dir}/stage/${module_name}/"*/*".tar.gz" | head -n1 \
+               || echo "/tmp/${USER}/failure.tmp")
+
+sha256sum "${file}"


### PR DESCRIPTION
Raspbian is used as base

It took less than 20 min to build on Ubuntu 18.04 x86_64

If merged other arch will come next, and then automated by CI.

Relate-to: https://github.com/mapbox/node-sqlite3/issues/418
Change-Id: Ic92baf3e019e28862a24d84728835a641a6838c1
Signed-off-by: Philippe Coval <p.coval@samsung.com>