### PR TITLE
prebuilt: add electon 4.1 & 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,6 +129,22 @@ matrix:
             packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
      - os: linux
        compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="4.2.0"
+       dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
+       addons:
+         apt:
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="4.1.0"
+       dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
+       addons:
+         apt:
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+     - os: linux
+       compiler: clang
        env: NODE_VERSION="6" ELECTRON_VERSION="4.0.0"
        dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
        addons:
@@ -183,6 +199,12 @@ matrix:
      - os: osx
        compiler: clang
        env: NODE_VERSION="6" ELECTRON_VERSION="5.0.0"
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="4.2.0"
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="4.1.0"
      - os: osx
        compiler: clang
        env: NODE_VERSION="6" ELECTRON_VERSION="4.0.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,16 @@ environment:
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 4.2.0
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 10
+      platform: x64
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 4.1.0
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 10
+      platform: x64
+      NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 4.0.0
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
     - nodejs_version: 10


### PR DESCRIPTION
These version were missed as reported by #1163 