### PR TITLE
Get rid of "request"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   },
   "dependencies": {
     "nan": "^2.12.1",
-    "node-pre-gyp": "^0.11.0",
-    "request": "^2.87.0"
+    "node-pre-gyp": "^0.11.0"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",


### PR DESCRIPTION
Request is not used anywhere, but it creates a security risk and brings tons of its own dependencies.
Also, its contributors don't want to release new version for a year.
We definitely should get rid of this.
issue #1148