### PR TITLE
prebuilt: add electron 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ matrix:
      # electron Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="12" ELECTRON_VERSION="6.0.0"
+       env: NODE_VERSION="6" ELECTRON_VERSION="6.0.0"
        dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
        addons:
          apt:
@@ -129,7 +129,7 @@ matrix:
             packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
      - os: linux
        compiler: clang
-       env: NODE_VERSION="12" ELECTRON_VERSION="5.0.0"
+       env: NODE_VERSION="6" ELECTRON_VERSION="5.0.0"
        dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
        addons:
          apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,14 @@ matrix:
      # electron Linux
      - os: linux
        compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="6.0.0"
+       dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
+       addons:
+         apt:
+            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+            packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+     - os: linux
+       compiler: clang
        env: NODE_VERSION="12" ELECTRON_VERSION="5.0.0"
        dist: trusty # needed for libc6 / 'version `GLIBC_2.17` not found' error on precise
        addons:
@@ -196,6 +204,9 @@ matrix:
             sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
             packages: [ 'clang-3.5']
      # electron MacOs
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="6" ELECTRON_VERSION="6.0.0"
      - os: osx
        compiler: clang
        env: NODE_VERSION="6" ELECTRON_VERSION="5.0.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,16 @@ environment:
     - nodejs_version: 12
       platform: x64
       NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 6.0.0
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 12
+      platform: x86
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 6.0.0
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+    - nodejs_version: 12
+      platform: x64
+      NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 5.0.0
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
     - nodejs_version: 12


### PR DESCRIPTION
This adds support for Electron 6.0.0. I used the same technique as https://github.com/mapbox/node-sqlite3/pull/1160 and https://github.com/mapbox/node-sqlite3/pull/1180.

Electron 6.0.0 was released on 7/30/2019.
https://electronjs.org/releases/stable#release-notes-for-v600