### PR TITLE
overwrite 'msbuild_toolset' only if 'toolset' is defined

### DIFF
--- a/deps/common-sqlite.gypi
+++ b/deps/common-sqlite.gypi
@@ -5,7 +5,11 @@
   },
   'target_defaults': {
     'default_configuration': 'Release',
-    'msbuild_toolset':'<(toolset)',
+    'conditions': [
+      [ 'toolset!=""', {
+        'msbuild_toolset':'<(toolset)'
+      }]
+    ],
     'configurations': {
       'Debug': {
         'defines!': [


### PR DESCRIPTION
node-gyp uses 'msbuild_toolset' in 'target_defaults' to specify what toolset should be used, according to what version of Visual Studio was detected.

Before this change, when 'toolset' was not specified, node-sqlite3 failed to compile with any version of Visual Studio after 2015, because gyp fails to detect the toolset correctly.

With this change 'toolset' is only used if defined, fixing compilation with node-gyp and recent VS versions.