### PR TITLE
deps: attempt upgrade node to v13 to force node-gyp to v6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,22 +59,22 @@ environment:
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.1.0
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
-    - nodejs_version: 12
+    - nodejs_version: 13
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.0.0
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
-    - nodejs_version: 12
+    - nodejs_version: 13
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.0.0
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
-    - nodejs_version: 12
+    - nodejs_version: 13
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 5.0.0
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
-    - nodejs_version: 12
+    - nodejs_version: 13
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 5.0.0


### PR DESCRIPTION
For the windows builds, attempt node upgrade to v13 for windows electron v5 & v6