### PR TITLE
Use minimum supported node version for Electron 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
      # electron Linux
      - os: linux
        compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="7.0.0"
+       env: NODE_VERSION="8" ELECTRON_VERSION="7.0.0"
        dist: trusty
        addons:
          apt:
@@ -233,7 +233,7 @@ matrix:
      # electron MacOs
      - os: osx
        compiler: clang
-       env: NODE_VERSION="6" ELECTRON_VERSION="7.0.0"     
+       env: NODE_VERSION="8" ELECTRON_VERSION="7.0.0"
      - os: osx
        compiler: clang
        env: NODE_VERSION="6" ELECTRON_VERSION="6.1.0"


### PR DESCRIPTION
Not sure if this change is right, but wondering if this is the reason the CI was failing with Electron 7.
Looks like the minimum supported node version for Electron 7 is Node 8