### PR TITLE
Remove unsupported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,6 @@ matrix:
             packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
      - os: linux
        compiler: clang
-       env: NODE_VERSION="9"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
        env: NODE_VERSION="8"
        addons:
          apt:
@@ -64,21 +57,7 @@ matrix:
             packages: [ 'clang-3.5']
      - os: linux
        compiler: clang
-       env: NODE_VERSION="7"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
        env: NODE_VERSION="6"
-       addons:
-         apt:
-            sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
-            packages: [ 'clang-3.5']
-     - os: linux
-       compiler: clang
-       env: NODE_VERSION="5"
        addons:
          apt:
             sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
@@ -113,19 +92,10 @@ matrix:
        env: NODE_VERSION="10" # node abi 64
      - os: osx
        compiler: clang
-       env: NODE_VERSION="9" # node abi 59
-     - os: osx
-       compiler: clang
        env: NODE_VERSION="8" # node abi 57
      - os: osx
        compiler: clang
-       env: NODE_VERSION="7" # node abi 51
-     - os: osx
-       compiler: clang
        env: NODE_VERSION="6" # node abi 48
-     - os: osx
-       compiler: clang
-       env: NODE_VERSION="5" # node abi 47
      - os: osx
        compiler: clang
        env: NODE_VERSION="4" # node abi 46

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,25 +6,13 @@ environment:
     - nodejs_version: 4
       platform: x86
       msvs_toolset: 12
-    - nodejs_version: 5
-      platform: x64
-    - nodejs_version: 5
-      platform: x86
     - nodejs_version: 6
       platform: x64
     - nodejs_version: 6
       platform: x86
-    - nodejs_version: 7
-      platform: x64
-    - nodejs_version: 7
-      platform: x86
     - nodejs_version: 8
       platform: x64
     - nodejs_version: 8
-      platform: x86
-    - nodejs_version: 9
-      platform: x64
-    - nodejs_version: 9
       platform: x86
     - nodejs_version: 10
       platform: x64


### PR DESCRIPTION
Trying to make CI builds faster, I removed the old node versions that are not listed in the Readme, assuming they are not really supported anymore.

Related to #1249 

Feel free to close this PR if you guys think it's still worth running these versions in the CI