### PR TITLE
refactor: use bindings to load .node file

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -1,7 +1,5 @@
-var binary = require('node-pre-gyp');
 var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
-var binding = require(binding_path);
+var binding = require('bindings')('node_sqlite3.node');
 var sqlite3 = module.exports = exports = binding;
 var EventEmitter = require('events').EventEmitter;
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "nan": "^2.12.1",
     "node-pre-gyp": "^0.11.0",
+    "bindings": "^1.5.0",
     "request": "^2.87.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR alters `.node` file loading to use `bindings`. I'd like to make this change because it enables Webpack to understand how to handle this module, a need which would apply to, for example, Electron apps which both need to use native node modules and use Webpack.

This should not disrupt any existing functionality, and `bindings` itself only has one dependency, which makes this change have minimal impact as far as added dependencies are concerned.

Thank you!