### PR TITLE
updated node-pre-gyp version to ^0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "nan": "^2.12.1",
-    "node-pre-gyp": "^0.11.0",
+    "node-pre-gyp": "^0.14.0",
     "request": "^2.87.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #1264 - Installing with --target=<target-node-version> results with "Unsupported target version" for targets >= 11