### PR TITLE
Fix Electron dist url

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ Set the location where `make` installed it:
 
 Running sqlite3 through [electron-rebuild](https://github.com/electron/electron-rebuild) does not preserve the sqlcipher extension, so some additional flags are needed to make this build Electron compatible. Your `npm install sqlite3 --build-from-source` command needs these additional flags (be sure to replace the target version with the current Electron version you are working with):
 
-    --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
+    --runtime=electron --target=1.7.6 --dist-url=https://electronjs.org/headers
 
 In the case of MacOS with Homebrew, the command should look like the following:
 
-    npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://atom.io/download/electron
+    npm install sqlite3 --build-from-source --sqlite_libname=sqlcipher --sqlite=`brew --prefix` --runtime=electron --target=1.7.6 --dist-url=https://electronjs.org/headers
 
 # Testing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,136 +47,136 @@ environment:
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 7.1.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 7.1.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 7.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 7.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.1.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.1.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 6.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 5.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 5.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 4.2.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 4.1.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 4.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 10
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 4.0.0
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 3.0.6
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 10
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 3.0.6
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 8
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 2.0.1
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 8
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 2.0.1
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 8
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.8.4
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 8
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.8.4
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 7
       platform: x64
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.7.12
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 7
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.7.12
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 6
       platform: x64
       msvs_toolset: 12
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.6.2
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 6
       platform: x86
       msvs_toolset: 12
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.6.2
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 6
       platform: x64
       msvs_toolset: 12
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.3.14
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 6
       platform: x86
       msvs_toolset: 12
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 1.3.14
-      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
 
 os: Visual Studio 2015
 

--- a/scripts/build_against_electron.sh
+++ b/scripts/build_against_electron.sh
@@ -5,7 +5,7 @@ source ~/.nvm/nvm.sh
 set -e -u
 
 export DISPLAY=":99.0"
-GYP_ARGS="--runtime=electron --target=${ELECTRON_VERSION} --dist-url=https://atom.io/download/electron"
+GYP_ARGS="--runtime=electron --target=${ELECTRON_VERSION} --dist-url=https://electronjs.org/headers"
 NPM_BIN_DIR="$(npm bin -g 2>/dev/null)"
 
 function publish() {


### PR DESCRIPTION
Deprecated since Electron v7.0.
https://github.com/electron/electron/blob/master/docs/breaking-changes.md#node-headers-url