### PR TITLE
Added json1 support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ db.close();
  - Full Buffer/Blob support
  - Extensive [debugging support](https://github.com/mapbox/node-sqlite3/wiki/Debugging)
  - [Query serialization](https://github.com/mapbox/node-sqlite3/wiki/Control-Flow) API
- - [Extension support](https://github.com/mapbox/node-sqlite3/wiki/Extensions)
+ - [Extension support](https://github.com/mapbox/node-sqlite3/wiki/Extensions), including bundled support for the [json1 extension](https://www.sqlite.org/json1.html).
  - Big test suite
  - Written in modern C++ and tested for memory leaks
  - Bundles Sqlite3 3.26.0 as a fallback if the installing system doesn't include SQLite


### PR DESCRIPTION
This PR adds a single mention to the bundled extension in the README.md file, to help surface this important feature inclusion, in hopes of saving others the time and anguish it took me to figure it out.

Per [PR 538](https://github.com/mapbox/node-sqlite3/pull/538/files), support for the [json1](https://www.sqlite.org/json1.html) extension has been bundled in the npm distribution since late 2015. However, this feature isn't surfaced anywhere in the documentation, or the wiki, and the only way to discover it is via reading the build configs or searching the closed PRs. Since json1 is the first extension listed in the [official docs](https://www.sqlite.org/docs.html), it makes sense to mention this inclusion in the docs.

Alternatively, a "bundled extensions" wiki entry could be created to mention all of the [bundled](https://github.com/mapbox/node-sqlite3/blob/bad9339d818dd61eb778577cb877ddbc151fd7bb/deps/sqlite3.gyp#L87-L91) extensions.