### PR TITLE
Don't require throw to add trace info for verbose mode

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -15,17 +15,14 @@ function extendTrace(object, property, pos) {
         var cb = arguments[pos];
         if (typeof arguments[pos] === 'function') {
             arguments[pos] = function replacement() {
-                try {
-                    return cb.apply(this, arguments);
-                } catch (err) {
-                    if (err && err.stack && !err.__augmented) {
-                        err.stack = filter(err).join('\n');
-                        err.stack += '\n--> in ' + name;
-                        err.stack += '\n' + filter(error).slice(1).join('\n');
-                        err.__augmented = true;
-                    }
-                    throw err;
+                var err = arguments[0];
+                if (err && err.stack && !err.__augmented) {
+                    err.stack = filter(err).join('\n');
+                    err.stack += '\n--> in ' + name;
+                    err.stack += '\n' + filter(error).slice(1).join('\n');
+                    err.__augmented = true;
                 }
+                return cb.apply(this, arguments);
             };
         }
         return old.apply(this, arguments);

--- a/test/verbose.test.js
+++ b/test/verbose.test.js
@@ -1,0 +1,60 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+
+var invalid_sql = 'update non_existent_table set id=1';
+
+var originalMethods = {
+    Database: {},
+    Statement: {},
+};
+
+function backupOriginalMethods() {
+    for (var obj in originalMethods) {
+        for (var attr in sqlite3[obj].prototype) {
+            originalMethods[obj][attr] = sqlite3[obj].prototype[attr];
+        }
+    }
+}
+
+function resetVerbose() {
+    for (var obj in originalMethods) {
+        for (var attr in originalMethods[obj]) {
+            sqlite3[obj].prototype[attr] = originalMethods[obj][attr];
+        }
+    }
+}
+
+describe('verbose', function() {
+    it('Shoud add trace info to error when verbose is called', function(done) {
+        var db = new sqlite3.Database(':memory:');
+        backupOriginalMethods();
+        sqlite3.verbose();
+
+        db.run(invalid_sql, function(err) {
+            assert(err instanceof Error);
+
+            assert(
+                err.stack.indexOf(`Database#run('${invalid_sql}'`) > -1,
+                `Stack shoud contain trace info, stack = ${err.stack}`
+            );
+
+            done();
+            resetVerbose();
+        });
+    });
+
+    it('Shoud not add trace info to error when verbose is not called', function(done) {
+        var db = new sqlite3.Database(':memory:');
+
+        db.run(invalid_sql, function(err) {
+            assert(err instanceof Error);
+
+            assert(
+                err.stack.indexOf(invalid_sql) === -1,
+                `Stack shoud not contain trace info, stack = ${err.stack}`
+            );
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1316 

Currently, `verbose()` adds trace info to the error object **only** if you `throw` the error by catching it inside a try/catch :

https://github.com/mapbox/node-sqlite3/blob/afa22076ba13ef3bc6afac892d9ed46a7ec36fc2/lib/trace.js#L18-L28

This doesn't work with promises as discussed in the linked issue because throwing in an async callback doesn't get caught by the promise or a wrapping try/catch.

this PR solves this issue by simply adding the trace info outside try/catch by checking the error object which is always the first argument.