### PR TITLE
Rebuild binaries before publishing

### DIFF
--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -140,6 +140,8 @@ CALL npm test
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 :NPM_TEST_FINISHED
+CALL node_modules\.bin\node-pre-gyp rebuild --msvs_version=%msvs_version% %TOOLSET_ARGS%
+IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 ECHO packaging for node-gyp
 CALL node_modules\.bin\node-pre-gyp package %TOOLSET_ARGS%
 ::make commit message env var shorter

--- a/scripts/build_against_electron.sh
+++ b/scripts/build_against_electron.sh
@@ -10,6 +10,7 @@ NPM_BIN_DIR="$(npm bin -g 2>/dev/null)"
 
 function publish() {
     if [[ ${PUBLISHABLE:-false} == true ]] && [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then
+        node-pre-gyp rebuild  --clang=1 $GYP_ARGS
         node-pre-gyp package $GYP_ARGS
         node-pre-gyp publish $GYP_ARGS
         node-pre-gyp info $GYP_ARGS

--- a/scripts/build_against_node.sh
+++ b/scripts/build_against_node.sh
@@ -6,6 +6,7 @@ set -e -u
 
 function publish() {
     if [[ ${PUBLISHABLE:-false} == true ]] && [[ ${COMMIT_MESSAGE} =~ "[publish binary]" ]]; then
+        CFLAGS="${CFLAGS:-} -include $(pwd)/src/gcc-preinclude.h" CXXFLAGS="${CXXFLAGS:-} -include $(pwd)/src/gcc-preinclude.h" node-pre-gyp rebuild  --clang=1
         node-pre-gyp package testpackage
         node-pre-gyp publish
         node-pre-gyp info


### PR DESCRIPTION
Executing "npm install --build-from-source" only builds the module for one of the N-API target versions. The build command has to be executed explicitly to generate builds targeting each of the specified N-API versions.

This should fix publishing binaries (which means this should fix #1424).