### PR TITLE
Update node-gyp and node-pre-gyp

### DIFF
--- a/lib/sqlite3-binding.js
+++ b/lib/sqlite3-binding.js
@@ -1,4 +1,4 @@
-var binary = require('node-pre-gyp');
+var binary = require('@mapbox/node-pre-gyp');
 var path = require('path');
 var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
 var binding = require(binding_path);

--- a/lib/sqlite3-binding.js
+++ b/lib/sqlite3-binding.js
@@ -1,4 +1,4 @@
-var binary = require('@mapbox/node-pre-gyp');
+var binary = require('node-pre-gyp');
 var path = require('path');
 var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
 var binding = require(binding_path);

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha": "^5.2.0"
   },
   "peerDependencies": {
-    "node-gyp": "3.x"
+    "node-gyp": "7.x"
   },
   "peerDependenciesMeta": {
     "node-gyp": {
@@ -59,7 +59,7 @@
     }
   },
   "optionalDependencies": {
-    "node-gyp": "3.x"
+    "node-gyp": "7.x"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "node-addon-api": "^3.0.0",
-    "node-pre-gyp": "^1.0.0"
+    "@mapbox/node-pre-gyp": "^1.0.0"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "node-addon-api": "^3.0.0",
-    "@mapbox/node-pre-gyp": "^1.0.0"
+    "node-pre-gyp": "^1.0.0"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "node-addon-api": "^3.0.0",
-    "node-pre-gyp": "^0.17.0"
+    "@mapbox/node-pre-gyp": "^1.0.0"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "node-addon-api": "^3.0.0",
-    "node-pre-gyp": "^0.11.0"
+    "node-pre-gyp": "^0.17.0"
   },
   "devDependencies": {
     "@mapbox/cloudfriend": "^1.9.0",


### PR DESCRIPTION
This is basically the same as #1361 and also updates `node-pre-gyp`. Without updating these two I'm running into all kinds of issues trying to rebuild from source for Electron and for Apple's `arm64`.
