### PR TITLE
bug: fix segfault of invalid toString() object

### DIFF
--- a/src/statement.cc
+++ b/src/statement.cc
@@ -205,7 +205,13 @@ template <class T> Values::Field*
         return new Values::Float(pos, source.ToNumber().DoubleValue());
     }
     else if (source.IsObject()) {
-        std::string val = source.ToString().Utf8Value();
+        Napi::String napiVal = source.ToString();
+        // Check whether toString returned a value that is not undefined.
+        if(napiVal.Type() == 0) {
+            return NULL;
+        }
+
+        std::string val = napiVal.Utf8Value();
         return new Values::Text(pos, val.length(), val.c_str());
     }
     else {

--- a/test/other_objects.test.js
+++ b/test/other_objects.test.js
@@ -86,4 +86,13 @@ describe('data types', function() {
             });
         });
     });
+
+    it('should ignore faulty toString', function(done) {
+        const faulty = { toString: 23 };
+        db.run("INSERT INTO txt_table VALUES(?)", faulty, function (err) {
+            assert.notEqual(err, undefined);
+            done();
+        });
+    });
+
 });


### PR DESCRIPTION
Verify ToString() returns valid data before casting to utf-8 encoding.
fixes #1440 
fixes #1449 