### PR TITLE
allow node-gyp v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,6 @@ jobs:
         if: matrix.os == 'macos-m1'
         run: npm install -g yarn
 
-      - name: Add setuptools for Python 3.12 (temp)
-        if: matrix.os != 'macos-m1'
-        run: pip install setuptools
-
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
         if: contains(matrix.os, 'windows')

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
   "devDependencies": {
     "eslint": "8.56.0",
     "mocha": "10.2.0",
-    "prebuild": "12.1.0"
+    "prebuild": "13.0.1"
   },
   "peerDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": ">=8"
   },
   "peerDependenciesMeta": {
     "node-gyp": {
@@ -63,7 +63,7 @@
     }
   },
   "optionalDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": ">=8"
   },
   "scripts": {
     "install": "prebuild-install -r napi || node-gyp rebuild",


### PR DESCRIPTION
Trying #1788 again, but addressing https://github.com/TryGhost/node-sqlite3/pull/1788#issuecomment-2842110183 by not changing the node requirement 

In case you do decide to drop support for older nodes, `node-gyp` supports the following:
* `^8`: [`>= 10.12.0`](https://github.com/nodejs/node-gyp/blob/v8.0.0/package.json#L37)
* `^9`: [`^12.22 || ^14.13 || >=16`](https://github.com/nodejs/node-gyp/blob/v9.0.0/package.json#L37)
* `^10`: [`^16.14.0 || >=18.0.0`](https://github.com/nodejs/node-gyp/blob/v10.0.0/package.json#L37)
* `^11`: [`^18.17.0 || >=20.5.0`](https://github.com/nodejs/node-gyp/blob/v11.0.0/package.json#L37)

Fixes #1752