### PR TITLE
Prebuild windows arm64 binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,18 @@ jobs:
             node: 24
             host: arm64
             target: arm64
+          - os: windows-11-arm
+            node: 20
+            host: arm64
+            target: arm64
+          - os: windows-11-arm
+            node: 22
+            host: arm64
+            target: arm64
+          - os: windows-11-arm
+            node: 24
+            host: arm64
+            target: arm64
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The module uses [`prebuild-install`](https://github.com/prebuild/prebuild-instal
 * `linux-x64`
 * `linuxmusl-arm64`
 * `linuxmusl-x64`
+* `win32-arm64`
 * `win32-x64`
 
 Unfortunately, [prebuild](https://github.com/prebuild/prebuild/issues/174) cannot differentiate between `armv6` and `armv7`, and instead uses `arm` as the `{arch}`. Until that is fixed, you will still need to install `sqlite3` from [source](#source-install).


### PR DESCRIPTION
Hey @jonatansberg, I know this repo is officially unmaintained, but I figured I'd try anyway.

This is an easy addition because Github now provides `windows-11-arm` runners.

Addresses:
- https://github.com/TryGhost/node-sqlite3/issues/1647
- https://github.com/TryGhost/node-sqlite3/issues/1799
- https://github.com/TryGhost/node-sqlite3/issues/1829
